### PR TITLE
Properly handle model outputs in scheduler

### DIFF
--- a/stream/classes/cost_model/scheduler.py
+++ b/stream/classes/cost_model/scheduler.py
@@ -353,20 +353,24 @@ def schedule_graph(
 
         ## Step 7
         # Memory usage: When the node ends:
-        # If this node is a sink node (node that has no successors and that produces a final output), transfer final outputs to offchip
-        if best_candidate in sink_layer_nodes:
-            top_level_idx = accelerator.memory_manager.get_top_level_idx(
-                core, output_tensor.memory_operand
-            )
-            # Only push back sink node outputs if they're generated and stored on the core
-            if not best_candidate.output_operand in best_candidate.too_large_operands:
+        # If the output is the final output for a model output node, copy it back to offchip.
+        if best_candidate.produces_final_output and best_candidate.is_model_output:
+            # only push node outputs if they're generated and stored on the core
+            if best_candidate.output_operand not in best_candidate.too_large_operands:
                 (
+                    _,
                     current_timestep,
                     link_energy_cost,
                     memory_energy_cost,
-                ) = accelerator.memory_manager.remove_tensor_from_core(
-                    core, top_level_idx, output_tensor, end, write_back_to_offchip=True
+                ) = accelerator.transfer_data(
+                    output_tensor,
+                    core,
+                    accelerator.offchip_core_id,
+                    output_tensor.memory_operand,
+                    end,
                 )
+                accelerator.memory_manager.add_tensor_to_core(output_tensor, accelerator.offchip_core_id, end, current_timestep, [], )
+
                 total_sink_layer_output_offchip_link_energy += link_energy_cost
                 total_sink_layer_output_offchip_memory_energy += memory_energy_cost
 

--- a/stream/classes/io/onnx/conv.py
+++ b/stream/classes/io/onnx/conv.py
@@ -191,6 +191,9 @@ class ConvParser(Parser):
             self.node, self.onnx_model
         )
 
+        # check whether this is an output node
+        is_model_output = get_onnx_tensor_type(self.node.output[0], self.onnx_model).category.is_output
+
         # Get the hw mapping of this node.
         if self.node.name in self.mapping:
             node_mapping = self.mapping[self.node.name]
@@ -230,6 +233,7 @@ class ConvParser(Parser):
             node_input_names,
             node_output_names,
             op_type,
+            is_model_output=is_model_output,
         )
 
         return node_obj

--- a/stream/classes/io/onnx/gemm.py
+++ b/stream/classes/io/onnx/gemm.py
@@ -1,7 +1,7 @@
 from zigzag.classes.io.onnx.parser import Parser
 from zigzag.classes.io.onnx.utils import (
     get_node_input_output_dimension_shapes,
-    get_attribute_ints_with_name,
+    get_attribute_ints_with_name, get_onnx_tensor_type,
 )
 from stream.classes.workload.computation_node import ComputationNode
 
@@ -102,6 +102,9 @@ class GemmParser(Parser):
         C = ia_dimension_shape[1]
         K = oa_dimension_shape[1]
 
+        # check whether this is an output node
+        is_model_output = get_onnx_tensor_type(self.node.output[0], self.onnx_model).category.is_output
+
         # Get the hw mapping of this node.
         if self.node.name in self.mapping:
             node_mapping = self.mapping[self.node.name]
@@ -130,6 +133,7 @@ class GemmParser(Parser):
             node_input_names,
             node_output_names,
             op_type,
+            is_model_output=is_model_output,
         )
 
         return node_obj

--- a/stream/classes/io/onnx/matmul.py
+++ b/stream/classes/io/onnx/matmul.py
@@ -1,7 +1,7 @@
 import onnx
 
 from zigzag.classes.io.onnx.parser import Parser
-from zigzag.classes.io.onnx.utils import get_node_input_output_dimension_shapes
+from zigzag.classes.io.onnx.utils import get_node_input_output_dimension_shapes, get_onnx_tensor_type
 from stream.classes.workload.computation_node import ComputationNode
 
 import logging
@@ -94,6 +94,9 @@ class MatMulParser(Parser):
         C = ia_dimension_shape[1]
         K = oa_dimension_shape[1]
 
+        # check whether this is an output node
+        is_model_output = get_onnx_tensor_type(self.node.output[0], self.onnx_model).category.is_output
+
         # Get the hw mapping of this node.
         if self.node.name in self.mapping:
             node_mapping = self.mapping[self.node.name]
@@ -122,6 +125,7 @@ class MatMulParser(Parser):
             node_input_names,
             node_output_names,
             op_type,
+            is_model_output=is_model_output,
         )
 
         return node_obj

--- a/stream/classes/stages/GenerateCNWorkloadHybridStage.py
+++ b/stream/classes/stages/GenerateCNWorkloadHybridStage.py
@@ -410,6 +410,7 @@ class GenerateCNWorkloadHybridStage(Stage):
                 node_output_names,
                 op_type=original_node.type,
                 produces_final_output=produces_final_output,
+                is_model_output=original_node.is_model_output,
             )
 
             # Initialize the priorities (total inter-CN data reuse factor) for the constant operands of this finer_node

--- a/stream/classes/stages/GenerateCNWorkloadStageNew.py
+++ b/stream/classes/stages/GenerateCNWorkloadStageNew.py
@@ -610,7 +610,8 @@ class GenerateCNWorkloadStage(Stage):
                 finer_node_name,
                 finer_node_input_names,
                 finer_node_output_names,
-                produces_final_output,
+                produces_final_output=produces_final_output,
+                is_model_output=original_node.produces_final_output,
             )
             finer_node.type = node_type
             finer_nodes.append(finer_node)

--- a/stream/classes/workload/computation_node.py
+++ b/stream/classes/workload/computation_node.py
@@ -31,6 +31,7 @@ class ComputationNode(LayerNode, Node):
         output_names,
         op_type="computation",
         produces_final_output=False,
+        is_model_output=False,
         add_missing_node_attrs=False,
     ):
         assert isinstance(
@@ -53,7 +54,12 @@ class ComputationNode(LayerNode, Node):
         )
 
         # Save whether this ComputationNode produces a final output
+        #   this is not whether this is an output of the model, only whether this node reaches
+        #   the end of the reduced loop ranges.
         self.produces_final_output = produces_final_output
+
+        # Save whether the output of the ComputationNode is an output of the model itself
+        self.is_model_output = is_model_output
 
         # Save the loop ranges of this ComputationNode
         self.loop_ranges: Dict[str, tuple] = node_attrs.get(

--- a/stream/classes/workload/dnn_workload.py
+++ b/stream/classes/workload/dnn_workload.py
@@ -2,7 +2,6 @@ import copy
 
 import networkx as nx
 
-from zigzag.classes.workload.layer_node import LayerNode
 from stream.classes.workload.computation_node import ComputationNode
 from typing import Dict, Any
 from networkx import DiGraph
@@ -79,6 +78,7 @@ class DNNWorkload(DiGraph):
                 op_type,
                 produces_final_output,
                 add_missing_node_attrs=True,
+                is_model_output=False,  # TODO what to do here?
             )
             """Save this layer_id and LayerNode pair in the layer_id_to_obj dict"""
             layer_id_to_obj[layer_id] = layer_node

--- a/stream/classes/workload/pooling_node.py
+++ b/stream/classes/workload/pooling_node.py
@@ -2,10 +2,6 @@ from stream.classes.workload.computation_node import ComputationNode
 
 
 class PoolingNode(ComputationNode):
-    def __init__(
-        self, node_id, node_attrs, node_name, node_input_names, node_output_names
-    ):
-        super().__init__(
-            node_id, node_attrs, node_name, node_input_names, node_output_names
-        )
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.type = "pooling"

--- a/stream/classes/workload/simd_node.py
+++ b/stream/classes/workload/simd_node.py
@@ -2,15 +2,6 @@ from stream.classes.workload.computation_node import ComputationNode
 
 
 class SimdNode(ComputationNode):
-    def __init__(
-        self,
-        node_id,
-        node_attrs,
-        node_name,
-        node_input_names,
-        node_output_names,
-        op_type,
-    ):
-        super().__init__(
-            node_id, node_attrs, node_name, node_input_names, node_output_names, op_type
-        )
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.type = "simd"


### PR DESCRIPTION
This PR depends on https://github.com/KULeuven-MICAS/zigzag/pull/17.

I don't think this is ready to merge yet, I have two questions:
* What nodes should `DNNWorkload` mark as output? The [old code](https://github.com/KULeuven-MICAS/stream/blob/5ddac2f3b3108506ea4df23ea67bb63cdd695870/stream/classes/workload/dnn_workload.py#L71) seems to check is a non-empty list is empty. Is it just the last layer? Any layer whose output is not used by any other layer? (this latter option would keep the old "sink node" behavior from the scheduler.
* Is this change to the scheduler correct? It's a bit strange how copying the tensor back and deleting it was tied together before. Is it okay to just copy it to offchip like I do here and then rely on the priority scheme to delete it automatically afterwards?