### PR TITLE
Fix latency optimized scheduling

### DIFF
--- a/stream/classes/cost_model/scheduler.py
+++ b/stream/classes/cost_model/scheduler.py
@@ -85,8 +85,7 @@ def get_best_candidate(candidates: list, candidate_selection: str):
     preds_ends, cn_candidates = zip(*candidates)
     if candidate_selection == "latency":
         # Get the best candidate: the one with the earliest possible start time
-        (preds_end, best_candidate) = min(candidates)
-        best_candidate_idx = preds_ends.index(preds_end)
+        ((preds_end, best_candidate), best_candidate_idx) = min(zip(candidates, range(len(candidates))))
     elif candidate_selection == "memory":
         # Get the best candidate: the one with the highest layer_id
         candidate_ids = [(cn.id[0], -cn.group, cn.id[1]) for cn in cn_candidates]


### PR DESCRIPTION
The latency optimized scheduling logic is not sound. When there are multiple candidates with the same `pred_end`, there are cases where `best_candidate != cn_candidates[best_candidate_idx]`.

As an illustrative example:
```python
candidates = [(0,4), (0, 3), (0, 5)]
preds_ends, cn_candidates = zip(*candidates)
(preds_end, best_candidate) = min(candidates) # (preds_end, best_candidate) = (0, 3) which its index is 1
best_candidate_idx = preds_ends.index(preds_end) # here the index is 0
```

This pull request fixes the bug