### PR TITLE
Fix data transfer cost bandwidth

### DIFF
--- a/stream/classes/hardware/architecture/accelerator.py
+++ b/stream/classes/hardware/architecture/accelerator.py
@@ -396,7 +396,7 @@ class Accelerator:
         )
         # Receiver memory energy
         nb_receiver_memory_writes_for_data = ceil(
-            tensor.size / sender_top_memory_level.write_bw
+            tensor.size / receiver_top_memory_level.write_bw
         )
         receiver_energy = (
             receiver_top_memory_level.write_energy * nb_receiver_memory_writes_for_data


### PR DESCRIPTION
The number of receiver writes required for a data transfer was wrongly using the sender memory level's bandwidth as opposed to the receiver memory level's bandwidth.