### PR TITLE
Fix given_node_hw_performances possibly not being assigned

### DIFF
--- a/stream/classes/stages/IntraCoreMappingStage.py
+++ b/stream/classes/stages/IntraCoreMappingStage.py
@@ -84,6 +84,8 @@ class IntraCoreMappingStage(Stage):
                 self.given_node_hw_performances = load_scme(self.node_hw_performances_path)
             except:
                 self.given_node_hw_performances = None
+        else:
+            self.given_node_hw_performances = None
 
         for node in self.unique_nodes:
             self.node_hw_performances[node] = {}


### PR DESCRIPTION
There is a chance that `self.given_node_hw_performances` is not assigned, and few lines later, it has been used

This fixes that