### PR TITLE
Remove accidentally added print statment

### DIFF
--- a/stream/classes/stages/GenerateCNWorkloadHybridStage.py
+++ b/stream/classes/stages/GenerateCNWorkloadHybridStage.py
@@ -440,7 +440,6 @@ class GenerateCNWorkloadHybridStage(Stage):
         # where the onnx tensors are always flattened back to 4D (merging the G+C or G+K into one channel dimension)
         dimensions, loop_ranges = self.flatten_grouped_convolution_ranges(producer, consumer, dimensions, loop_ranges)
         bounding_box = [loop_ranges[dim] for dim in dimensions]
-        print(bounding_box)
 
         if not interleaved:
             bounding_box_flat = tuple([item for sublist in bounding_box for item in sublist])


### PR DESCRIPTION
Removing a print statment that I think accidentally got included