### PR TITLE
Correctly infer scheduling order of CNs given layer stacks

### DIFF
--- a/.github/workflows/python-can-run-main-testing.yml
+++ b/.github/workflows/python-can-run-main-testing.yml
@@ -1,4 +1,4 @@
-name: Python can run
+name: Python main testing
 
 # Controls when the workflow will run
 on: [push]
@@ -25,10 +25,6 @@ jobs:
           pip install -r requirements.txt
       - name: Run without errors
         run: |
-          python main_stream_layer_splitting.py
-          python main_stream_mode_3.py
-          python main_stream_mode_4.py
-          python main_stream.py
           python main_testing_1_core_with_testing_workload.py
           python main_testing_2_cores_shared.py
           python main_testing_2_cores_with_testing_workload_3_layers.py

--- a/.github/workflows/python-can-run-main.yml
+++ b/.github/workflows/python-can-run-main.yml
@@ -1,0 +1,32 @@
+name: Python main
+
+# Controls when the workflow will run
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Display Python version
+        run: python -c "import sys; print(sys.version)"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run without errors
+        run: |
+          python main_stream_layer_splitting.py
+          python main_stream_mode_3.py
+          python main_stream_mode_4.py
+          python main_stream.py
+          python main_stream_layer_stacks.py

--- a/.github/workflows/python-can-run.yml
+++ b/.github/workflows/python-can-run.yml
@@ -2,10 +2,6 @@ name: Python can run
 
 # Controls when the workflow will run
 on: [push]
-  push:
-    branches: [ "master" ]
-  pull_request:
-    branches: [ "master" ]
 
 jobs:
   build:

--- a/.github/workflows/python-can-run.yml
+++ b/.github/workflows/python-can-run.yml
@@ -2,6 +2,10 @@ name: Python can run
 
 # Controls when the workflow will run
 on: [push]
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
 
 jobs:
   build:

--- a/main_stream.py
+++ b/main_stream.py
@@ -35,7 +35,7 @@ nb_ga_generations = 4  # number of genetic algorithm generations
 ######################################################################
 
 ################################PARSING###############################
-hw_name = accelerator.split(".")[-1]
+hw_name = accelerator.split("/")[-1].split(".")[0]
 wl_name = re.split(r"/|\.", workload_path)[-1]
 if wl_name == "onnx":
     wl_name = re.split(r"/|\.", workload_path)[-2]

--- a/main_stream_layer_splitting.py
+++ b/main_stream_layer_splitting.py
@@ -35,7 +35,7 @@ nb_ga_generations = 16  # number of genetic algorithm generations
 ######################################################################
 
 ################################PARSING###############################
-hw_name = accelerator.split(".")[-1]
+hw_name = accelerator.split("/")[-1].split(".")[0]
 wl_name = re.split(r"/|\.", workload_path)[-1]
 if wl_name == "onnx":
     wl_name = re.split(r"/|\.", workload_path)[-2]

--- a/main_stream_layer_stacks.py
+++ b/main_stream_layer_stacks.py
@@ -4,22 +4,22 @@ import re
 
 from zigzag.stages.MainStage import MainStage
 
-from stream.stages.parsing.accelerator_parser import (
-    AcceleratorParserStage as AcceleratorParserStage_,
-)
+from stream.stages.allocation.genetic_algorithm_allocation import GeneticAlgorithmAllocationStage
+from stream.stages.estimation.zigzag_core_mapping_estimation import ZigZagCoreMappingEstimationStage
 from stream.stages.generation.hint_loops_generation import HintLoopsGenerationStage
-from stream.stages.generation.layer_stacks_generation import LayerStacksGenerationStage
-from stream.stages.generation.scheduling_order_generation import SchedulingOrderGenerationStage
 from stream.stages.generation.hint_loops_partitioned_workload_generation import (
     HintLoopsPartitionedWorkloadGenerationStage,
 )
-from stream.stages.allocation.genetic_algorithm_allocation import GeneticAlgorithmAllocationStage
-from stream.stages.estimation.zigzag_core_mapping_estimation import ZigZagCoreMappingEstimationStage
+from stream.stages.generation.layer_stacks_generation import LayerStacksGenerationStage
+from stream.stages.generation.scheduling_order_generation import SchedulingOrderGenerationStage
+from stream.stages.parsing.accelerator_parser import (
+    AcceleratorParserStage as AcceleratorParserStage_,
+)
 from stream.stages.parsing.onnx_model_parser import ONNXModelParserStage as StreamONNXModelParserStage
-from stream.visualization.memory_usage import plot_memory_usage # type: ignore
+from stream.visualization.memory_usage import plot_memory_usage  # type: ignore
 from stream.visualization.schedule import (
     plot_timeline_brokenaxes,
-    visualize_timeline_plotly, # type: ignore
+    visualize_timeline_plotly,  # type: ignore
 )
 
 _logging_level = _logging.INFO

--- a/main_stream_layer_stacks.py
+++ b/main_stream_layer_stacks.py
@@ -1,0 +1,119 @@
+import logging as _logging
+import pickle
+import re
+
+from zigzag.stages.MainStage import MainStage
+
+from stream.classes.stages.AcceleratorParserStage import (
+    AcceleratorParserStage as AcceleratorParserStage_,
+)
+from stream.classes.stages.DetermineLayerStacksStage import DetermineLayerStacksStage
+from stream.classes.stages.DetermineHintLoopsStage import DetermineHintLoopsStage
+from stream.classes.stages.DetermineSchedulingOrderStage import DetermineSchedulingOrderStage
+from stream.classes.stages.GenerateCNWorkloadHybridStage import GenerateCNWorkloadHybridStage
+from stream.classes.stages.InterCoreMappingStage import InterCoreMappingStage
+from stream.classes.stages.IntraCoreMappingStage import IntraCoreMappingStage
+from stream.classes.stages.ModelParserStage import ONNXModelParserStage as StreamONNXModelParserStage
+from stream.visualization.memory_usage import plot_memory_usage
+from stream.visualization.schedule import (
+    plot_timeline_brokenaxes,
+    visualize_timeline_plotly,
+)
+
+_logging_level = _logging.INFO
+_logging_format = "%(asctime)s - %(name)s.%(funcName)s +%(lineno)s - %(levelname)s - %(message)s"
+_logging.basicConfig(level=_logging_level, format=_logging_format)
+
+################################INPUTS################################
+accelerator = "stream/inputs/examples/hardware/tpu_like_quad_core.yaml"
+workload_path = "stream/inputs/examples/workload/resnet18.onnx"
+mapping_path = "stream/inputs/examples/mapping/tpu_like_quad_core.yaml"
+mode = "fused"
+nb_ga_individuals = 4  # number of individuals in each generation
+nb_ga_generations = 4  # number of genetic algorithm generations
+######################################################################
+
+################################PARSING###############################
+hw_name = accelerator.split("/")[-1].split(".")[0]
+wl_name = re.split(r"/|\.", workload_path)[-1]
+if wl_name == "onnx":
+    wl_name = re.split(r"/|\.", workload_path)[-2]
+experiment_id = f"{hw_name}-{wl_name}-{mode}-auto-layer-stacks"
+node_hw_cost_pkl_name = f"{experiment_id}-saved_cn_hw_cost"
+scme_pkl_name = f"{experiment_id}-scme"
+######################################################################
+
+############PLOTTING#############
+plot_file_name = f"-{experiment_id}-"
+plot_full_schedule = True
+draw_dependencies = True
+plot_data_transfer = True
+section_start_percent = (0,)
+percent_shown = (100,)
+#################################
+
+
+################################PATHS################################
+node_hw_performances_path = f"outputs/{node_hw_cost_pkl_name}.pickle"
+scme_path = f"outputs/{scme_pkl_name}.pickle"
+timeline_fig_path_plotly = f"outputs/{experiment_id}-schedule.html"
+timeline_fig_path_matplotlib = f"outputs/{experiment_id}-schedule.png"
+memory_fig_path = f"outputs/{experiment_id}-memory.png"
+#####################################################################
+
+
+mainstage = MainStage(
+    [  # Initializes the MainStage as entry point
+        AcceleratorParserStage_,  # Parses the accelerator
+        StreamONNXModelParserStage,  # Parses the ONNX Model into the workload
+        DetermineLayerStacksStage,
+        DetermineHintLoopsStage,
+        # UserDefinedModelParserStage,  # Parses the user-defined Model into the workload
+        GenerateCNWorkloadHybridStage,
+        IntraCoreMappingStage,
+        DetermineSchedulingOrderStage,
+        InterCoreMappingStage,
+    ],
+    accelerator=accelerator,  # required by AcceleratorParserStage
+    workload_path=workload_path,  # required by ModelParserStage
+    mapping_path=mapping_path,  # required by ModelParserStage
+    loma_lpf_limit=6,  # required by LomaStage
+    nb_ga_individuals=nb_ga_individuals,  # number of individuals in each genetic algorithm generation
+    nb_ga_generations=nb_ga_generations,  # number of genetic algorithm generations
+    node_hw_performances_path=node_hw_performances_path,  # saved node_hw_performances to skip re-computation
+    plot_hof=True,  # Save schedule and memory usage plot of each individual in the Genetic Algorithm hall of fame
+    plot_file_name=plot_file_name,
+    plot_full_schedule=plot_full_schedule,
+    plot_data_transfer=plot_data_transfer,
+    scheduler_candidate_selection="memory",
+    operands_to_prefetch=[],
+    mode=mode,
+)
+
+# Launch the MainStage
+
+scme, _ = mainstage.run()
+scme = scme[0]
+
+# Save the scme to a pickle file
+with open(scme_path, "wb") as fp:
+    pickle.dump(scme, fp)
+
+# Plotting results using Plotly
+visualize_timeline_plotly(
+    scme,
+    draw_dependencies=draw_dependencies,
+    draw_communication=plot_data_transfer,
+    fig_path=timeline_fig_path_plotly,
+)
+
+# Ploting results using Matplotlib
+plot_timeline_brokenaxes(
+    scme,
+    draw_dependencies,
+    section_start_percent,
+    percent_shown,
+    plot_data_transfer,
+    fig_path=timeline_fig_path_matplotlib,
+)
+plot_memory_usage(scme, section_start_percent, percent_shown, fig_path=memory_fig_path)

--- a/main_stream_layer_stacks.py
+++ b/main_stream_layer_stacks.py
@@ -4,20 +4,22 @@ import re
 
 from zigzag.stages.MainStage import MainStage
 
-from stream.classes.stages.AcceleratorParserStage import (
+from stream.stages.parsing.accelerator_parser import (
     AcceleratorParserStage as AcceleratorParserStage_,
 )
-from stream.classes.stages.DetermineHintLoopsStage import DetermineHintLoopsStage
-from stream.classes.stages.DetermineLayerStacksStage import DetermineLayerStacksStage
-from stream.classes.stages.DetermineSchedulingOrderStage import DetermineSchedulingOrderStage
-from stream.classes.stages.GenerateCNWorkloadHybridStage import GenerateCNWorkloadHybridStage
-from stream.classes.stages.InterCoreMappingStage import InterCoreMappingStage
-from stream.classes.stages.IntraCoreMappingStage import IntraCoreMappingStage
-from stream.classes.stages.ModelParserStage import ONNXModelParserStage as StreamONNXModelParserStage
-from stream.visualization.memory_usage import plot_memory_usage
+from stream.stages.generation.hint_loops_generation import HintLoopsGenerationStage
+from stream.stages.generation.layer_stacks_generation import LayerStacksGenerationStage
+from stream.stages.generation.scheduling_order_generation import SchedulingOrderGenerationStage
+from stream.stages.generation.hint_loops_partitioned_workload_generation import (
+    HintLoopsPartitionedWorkloadGenerationStage,
+)
+from stream.stages.allocation.genetic_algorithm_allocation import GeneticAlgorithmAllocationStage
+from stream.stages.estimation.zigzag_core_mapping_estimation import ZigZagCoreMappingEstimationStage
+from stream.stages.parsing.onnx_model_parser import ONNXModelParserStage as StreamONNXModelParserStage
+from stream.visualization.memory_usage import plot_memory_usage # type: ignore
 from stream.visualization.schedule import (
     plot_timeline_brokenaxes,
-    visualize_timeline_plotly,
+    visualize_timeline_plotly, # type: ignore
 )
 
 _logging_level = _logging.INFO
@@ -67,13 +69,13 @@ mainstage = MainStage(
     [  # Initializes the MainStage as entry point
         AcceleratorParserStage_,  # Parses the accelerator
         StreamONNXModelParserStage,  # Parses the ONNX Model into the workload
-        DetermineLayerStacksStage,
-        DetermineHintLoopsStage,
+        LayerStacksGenerationStage,
+        HintLoopsGenerationStage,
         # UserDefinedModelParserStage,  # Parses the user-defined Model into the workload
-        GenerateCNWorkloadHybridStage,
-        IntraCoreMappingStage,
-        DetermineSchedulingOrderStage,
-        InterCoreMappingStage,
+        HintLoopsPartitionedWorkloadGenerationStage,
+        ZigZagCoreMappingEstimationStage,
+        SchedulingOrderGenerationStage,
+        GeneticAlgorithmAllocationStage,
     ],
     accelerator=accelerator,  # required by AcceleratorParserStage
     workload_path=workload_path,  # required by ModelParserStage

--- a/main_stream_layer_stacks.py
+++ b/main_stream_layer_stacks.py
@@ -7,8 +7,8 @@ from zigzag.stages.MainStage import MainStage
 from stream.classes.stages.AcceleratorParserStage import (
     AcceleratorParserStage as AcceleratorParserStage_,
 )
-from stream.classes.stages.DetermineLayerStacksStage import DetermineLayerStacksStage
 from stream.classes.stages.DetermineHintLoopsStage import DetermineHintLoopsStage
+from stream.classes.stages.DetermineLayerStacksStage import DetermineLayerStacksStage
 from stream.classes.stages.DetermineSchedulingOrderStage import DetermineSchedulingOrderStage
 from stream.classes.stages.GenerateCNWorkloadHybridStage import GenerateCNWorkloadHybridStage
 from stream.classes.stages.InterCoreMappingStage import InterCoreMappingStage

--- a/main_stream_layer_stacks.py
+++ b/main_stream_layer_stacks.py
@@ -31,6 +31,7 @@ mapping_path = "stream/inputs/examples/mapping/tpu_like_quad_core.yaml"
 mode = "fused"
 nb_ga_individuals = 4  # number of individuals in each generation
 nb_ga_generations = 4  # number of genetic algorithm generations
+layer_stacks = [tuple(range(0, 42)), (43,), (44,), (46,), (48,)]  # can be None for automatic layer stacks
 ######################################################################
 
 ################################PARSING###############################
@@ -88,6 +89,7 @@ mainstage = MainStage(
     scheduler_candidate_selection="memory",
     operands_to_prefetch=[],
     mode=mode,
+    layer_stacks=layer_stacks,
 )
 
 # Launch the MainStage

--- a/main_stream_mode_3.py
+++ b/main_stream_mode_3.py
@@ -35,7 +35,7 @@ nb_ga_generations = 16  # number of genetic algorithm generations
 ######################################################################
 
 ################################ PARSING###############################
-hw_name = accelerator.split(".")[-1]
+hw_name = accelerator.split("/")[-1].split(".")[0]
 wl_name = re.split(r"/|\.", workload_path)[-1]
 if wl_name == "onnx":
     wl_name = re.split(r"/|\.", workload_path)[-2]

--- a/main_stream_mode_4.py
+++ b/main_stream_mode_4.py
@@ -36,7 +36,7 @@ nb_ga_generations = 16  # number of genetic algorithm generations
 ######################################################################
 
 ################################PARSING###############################
-hw_name = accelerator.split(".")[-1]
+hw_name = accelerator.split("/")[-1].split(".")[0]
 wl_name = re.split(r"/|\.", workload_path)[-1]
 if wl_name == "onnx":
     wl_name = re.split(r"/|\.", workload_path)[-2]

--- a/main_testing_1_core_with_testing_workload.py
+++ b/main_testing_1_core_with_testing_workload.py
@@ -26,7 +26,7 @@ mapping_path = "stream/inputs/testing/mapping/testing_mapping.yaml"
 CN_define_mode = 1  # manually define outer CN size for all cores and all layers
 hint_loops = [("OY", "all")]  # outer CN loops, with error in resnet18 plotting
 
-hw_name = accelerator.split(".")[-1]
+hw_name = accelerator.split("/")[-1].split(".")[0]
 wl_name = re.split(r"/|\.", workload_path)[-1]
 experiment_id = f"{hw_name}-{wl_name}-CNmode_{CN_define_mode}-hintloop_{str(hint_loops)}"
 node_hw_cost_pkl_name = f"saved_CN_HW_cost-{experiment_id}"

--- a/main_testing_2_cores_shared.py
+++ b/main_testing_2_cores_shared.py
@@ -26,7 +26,7 @@ CN_define_mode = 1  # manually define outer CN size for all cores and all layers
 # hint_loops = [('OY', 'all')]  # outer CN loops, with error in resnet18 plotting
 hint_loops = []
 
-hw_name = accelerator.split(".")[-1]
+hw_name = accelerator.split("/")[-1].split(".")[0]
 wl_name = re.split(r"/|\.", workload_path)[-1]
 if wl_name == "onnx":
     wl_name = re.split(r"/|\.", workload_path)[-2]

--- a/main_testing_2_cores_with_testing_workload.py
+++ b/main_testing_2_cores_with_testing_workload.py
@@ -27,7 +27,7 @@ workload_path = "stream/inputs/testing/workload/testing_workload_for_2_cores.yam
 mapping_path = "stream/inputs/testing/mapping/testing_mapping.yaml"
 
 
-hw_name = accelerator.split(".")[-1]
+hw_name = accelerator.split("/")[-1].split(".")[0]
 wl_name = re.split(r"/|\.", workload_path)[-1]
 experiment_id = f"{hw_name}-{wl_name}-CNmode_{CN_define_mode}-hintloop_{str(hint_loops)}"
 node_hw_cost_pkl_name = f"saved_CN_HW_cost-{experiment_id}"

--- a/main_testing_2_cores_with_testing_workload_3_layers.py
+++ b/main_testing_2_cores_with_testing_workload_3_layers.py
@@ -26,7 +26,7 @@ mapping_path = "stream/inputs/testing/mapping/testing_mapping.yaml"
 CN_define_mode = 1  # manually define outer CN size for all cores and all layers
 hint_loops = [("OY", "all")]  # outer CN loops, with error in resnet18 plotting
 
-hw_name = accelerator.split(".")[-1]
+hw_name = accelerator.split("/")[-1].split(".")[0]
 wl_name = re.split(r"/|\.", workload_path)[-1]
 experiment_id = f"{hw_name}-{wl_name}-CNmode_{CN_define_mode}-hintloop_{str(hint_loops)}"
 node_hw_cost_pkl_name = f"saved_CN_HW_cost-{experiment_id}"

--- a/main_testing_4_cores_with_testing_workload.py
+++ b/main_testing_4_cores_with_testing_workload.py
@@ -26,7 +26,7 @@ mapping_path = "stream/inputs/testing/mapping/testing_mapping.yaml"
 CN_define_mode = 1  # manually define outer CN size for all cores and all layers
 hint_loops = [("OY", "all")]  # outer CN loops, with error in resnet18 plotting
 
-hw_name = accelerator.split(".")[-1]
+hw_name = accelerator.split("/")[-1].split(".")[0]
 wl_name = re.split(r"/|\.", workload_path)[-1]
 experiment_id = f"{hw_name}-{wl_name}-CNmode_{CN_define_mode}-hintloop_{str(hint_loops)}"
 node_hw_cost_pkl_name = f"saved_CN_HW_cost-{experiment_id}"

--- a/stream/stages/generation/hint_loops_generation.py
+++ b/stream/stages/generation/hint_loops_generation.py
@@ -28,6 +28,7 @@ class HintLoopsGenerationStage(Stage):
         elif self.mode == "lbl":
             if self.hint_loops is None:
                 self.hint_loops = self.get_hint_loops_lbl()
+                self.kwargs["cn_define_mode"] = 3
         else:
             raise ValueError("Unsupported mode for hint loops determination.")
 

--- a/stream/stages/generation/layer_stacks_generation.py
+++ b/stream/stages/generation/layer_stacks_generation.py
@@ -34,7 +34,8 @@ class LayerStacksGenerationStage(Stage):
         for core in self.accelerator.cores.node_list:
             if core.id == self.accelerator.offchip_core_id:
                 continue  # skip offchip core
-            core_weight_capacity = core.memory_hierarchy.get_operand_top_level(MemoryOperand("I2")).memory_instance.size
+            mem_op = MemoryOperand("I2")
+            core_weight_capacity = core.memory_hierarchy.get_operand_top_level(mem_op).memory_instance.size
             weight_capacities[core.id] = core_weight_capacity
 
         # Total weight capacity in bits

--- a/stream/stages/generation/scheduling_order_generation.py
+++ b/stream/stages/generation/scheduling_order_generation.py
@@ -26,12 +26,16 @@ class SchedulingOrderGenerationStage(Stage):
         self.scheduling_order = None
 
     def run(self):
-        # TODO: Take into account the layer stacks
         if self.layer_stacks:
-            logger.warn("Scheduling order for layer stacks not implemented.")
-        # Generate a list of node ids from highest priority to lowest
-        # We give higher priority to nodes deeper in the graph
-        self.scheduling_order = sorted(((n.id, n.sub_id) for n in self.workload.node_list), reverse=True)
+            # All nodes of earlier stacks should be scheduled before later stacks
+            self.scheduling_order = []
+            for layer_stack in self.layer_stacks:
+                nodes = [n for n in self.workload.nodes() if n.id in layer_stack]
+                self.scheduling_order.extend(sorted(((n.id, n.sub_id) for n in nodes), reverse=True))
+        else:
+            # Generate a list of node ids from highest priority to lowest
+            # We give higher priority to nodes deeper in the graph
+            self.scheduling_order = sorted(((n.id, n.sub_id) for n in self.workload.nodes()), reverse=True)
 
         self.kwargs["accelerator"] = self.accelerator
         self.kwargs["workload"] = self.workload


### PR DESCRIPTION
Up until now, the scheduling order of CNs was always a reversed-order list based on the node id and sub_id.

This PR incorporates the layer stacks, such that ids of an earlier stack will always have higher priority than ids of a later stack.