### PR TITLE
Correct use of get_total_inst_bandwidth in ZigZag

### DIFF
--- a/stream/stages/set_fixed_allocation_performance.py
+++ b/stream/stages/set_fixed_allocation_performance.py
@@ -91,7 +91,13 @@ class SetFixedAllocationPerformanceStage(Stage):
         assert self.accelerator.offchip_core_id is not None, "Off-chip core id is not set."
         offchip_core = self.accelerator.get_core(self.accelerator.offchip_core_id)
         offchip_instance = next(iter(offchip_core.mem_hierarchy_dict.values()))[-1].memory_instance
-        offchip_bandwidth = cme.get_total_inst_bandwidth(offchip_instance)
+        try:
+            offchip_level = next(level for level in cme.mem_level_list if level.memory_instance == offchip_instance)
+        except StopIteration:
+            raise ValueError(
+                f"Offchip instance {offchip_instance} not found in this CME's memory hierarchy " f"{cme.mem_level_list}"
+            )
+        offchip_bandwidth = cme.get_total_inst_bandwidth(offchip_level)
         return offchip_bandwidth
 
     @staticmethod


### PR DESCRIPTION
The use of `get_total_inst_bandwidth` is no longer up to date after https://github.com/KULeuven-MICAS/zigzag/pull/92:

- The ZigZag method `get_total_inst_bandwidth` expects a `MemoryLevel` but Stream calls it with a `MemoryInstance`
- Stream extracts the DRAM memory level from the DRAM core, where all operands (`I1`, `I2`, `O`) are defined, but the CostModelEvaluations contain copies of the DRAM level with only a subset of the operands (e.g. `I1`, `I2`) so the correct DRAM level could not be found

**This fix is normally already included in https://github.com/KULeuven-MICAS/stream/pull/54**