### PR TITLE
Update blocking behavior

### DIFF
--- a/stream/hardware/architecture/accelerator.py
+++ b/stream/hardware/architecture/accelerator.py
@@ -323,7 +323,7 @@ class Accelerator:
             links,
             evictions_complete_timestep,
             transfer_duration,
-            [tensor],
+            {link: [tensor] for link in links},
         )
         transfer_end = transfer_start + transfer_duration
         ################################# STEP 5 #################################


### PR DESCRIPTION
This PR updates the blocking behavior of CommunicationLink objects to differentiate tensors across multiple links.

If for example both ports of a dual-port offchip memory should be blocked during execution of a CN (port to offchip and port from offchip), previously it would incorrectly use both input and output tensors in blocking of all of them.
This caused issues with broadcasting not being detected correctly.
