### PR TITLE
Add custom CoreValidator

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-zigzag-dse==3.7.2
+zigzag-dse==3.8.0
 rtree
 deap
 matplotlib

--- a/stream/inputs/examples/hardware/cores/eyeriss_like.yaml
+++ b/stream/inputs/examples/hardware/cores/eyeriss_like.yaml
@@ -112,8 +112,8 @@ memories:
     served_dimensions: [D1, D2]
 
 operational_array:
-  multiplier_energy: 0.5 # pJ
-  multiplier_area: 0.1 # unit
+  unit_energy: 0.5 # pJ
+  unit_area: 0.1 # unit
   dimensions: [D1, D2]
   sizes: [14, 12]
 

--- a/stream/inputs/examples/hardware/cores/fusemax_array.yaml
+++ b/stream/inputs/examples/hardware/cores/fusemax_array.yaml
@@ -86,8 +86,8 @@ memories:
     served_dimensions: [D1, D2]
 
 operational_array:
-  multiplier_energy: 1.5
-  multiplier_area: 1 # unit
+  unit_energy: 1.5
+  unit_area: 1 # unit
   dimensions: [D1, D2]
   sizes: [256, 256]
 

--- a/stream/inputs/examples/hardware/cores/fusemax_dram.yaml
+++ b/stream/inputs/examples/hardware/cores/fusemax_dram.yaml
@@ -28,7 +28,7 @@ memories:
 
 operational_array:
   input_precision: [0, 0]
-  multiplier_energy: 0
-  multiplier_area: 0
+  unit_energy: 0
+  unit_area: 0
   dimensions: [D1, D2]
   sizes: [0, 0]

--- a/stream/inputs/examples/hardware/cores/fusemax_vec.yaml
+++ b/stream/inputs/examples/hardware/cores/fusemax_vec.yaml
@@ -87,7 +87,7 @@ memories:
 
 operational_array:
   input_precision: [8, 8]
-  multiplier_energy: 0.1 # pJ
-  multiplier_area: 0.01 # unit
+  unit_energy: 0.1 # pJ
+  unit_area: 0.01 # unit
   dimensions: [D1, D2]
   sizes: [256, 1]

--- a/stream/inputs/examples/hardware/cores/meta_prototype.yaml
+++ b/stream/inputs/examples/hardware/cores/meta_prototype.yaml
@@ -119,7 +119,7 @@ memories:
     served_dimensions: [D1, D2, D3, D4]
 
 multipliers:
-  multiplier_energy: 0.04 # pJ
-  multiplier_area: 1 # unit
+  unit_energy: 0.04 # pJ
+  unit_area: 1 # unit
   dimensions: [D1, D2, D3, D4]
   sizes: [32, 2, 4, 4]

--- a/stream/inputs/examples/hardware/cores/offchip.yaml
+++ b/stream/inputs/examples/hardware/cores/offchip.yaml
@@ -25,7 +25,7 @@ memories:
     served_dimensions: [D1, D2]
 
 operational_array:
-  multiplier_energy: 0
-  multiplier_area: 0
+  unit_energy: 0
+  unit_area: 0
   dimensions: [D1, D2]
   sizes: [0, 0]

--- a/stream/inputs/examples/hardware/cores/pooling.yaml
+++ b/stream/inputs/examples/hardware/cores/pooling.yaml
@@ -26,8 +26,8 @@ memories:
 
 
 operational_array:
-  multiplier_energy: 0.1 # pJ
-  multiplier_area: 0.01 # unit
+  unit_energy: 0.1 # pJ
+  unit_area: 0.01 # unit
   dimensions: [D1, D2, D3]
   sizes: [3, 3, 8]
 

--- a/stream/inputs/examples/hardware/cores/simba_chiplet.yaml
+++ b/stream/inputs/examples/hardware/cores/simba_chiplet.yaml
@@ -97,8 +97,8 @@ memories:
 
 
 operational_array:
-  multiplier_energy: 0.04  # Refine with more accurate data if available
-  multiplier_area: 1  # unit
+  unit_energy: 0.04  # Refine with more accurate data if available
+  unit_area: 1  # unit
   # D1/2 = 4x4 PE array. Each PE has 8 vector MACS (D3) that process 8 elements (D4) in parallel
   dimensions: [D1, D2, D3, D4]
   sizes: [4, 4, 8, 8]

--- a/stream/inputs/examples/hardware/cores/simba_offchip.yaml
+++ b/stream/inputs/examples/hardware/cores/simba_offchip.yaml
@@ -25,7 +25,7 @@ memories:
     served_dimensions: [D1, D2]
 
 operational_array:
-  multiplier_energy: 0
-  multiplier_area: 0
+  unit_energy: 0
+  unit_area: 0
   dimensions: [D1, D2]
   sizes: [0, 0]

--- a/stream/inputs/examples/hardware/cores/simd.yaml
+++ b/stream/inputs/examples/hardware/cores/simd.yaml
@@ -25,8 +25,8 @@ memories:
     served_dimensions: [D1]
 
 operational_array:
-  multiplier_energy: 0.1 # pJ
-  multiplier_area: 0.01 # unit
+  unit_energy: 0.1 # pJ
+  unit_area: 0.01 # unit
   dimensions: [D1]
   sizes: [64]
 

--- a/stream/inputs/examples/hardware/cores/tpu_like.yaml
+++ b/stream/inputs/examples/hardware/cores/tpu_like.yaml
@@ -64,8 +64,8 @@ memories:
     served_dimensions: [D1, D2]
 
 operational_array:
-  multiplier_energy: 0.04 # pJ
-  multiplier_area: 1 # unit
+  unit_energy: 0.04 # pJ
+  unit_area: 1 # unit
   dimensions: [D1, D2]
   sizes: [32, 32]
 

--- a/stream/inputs/testing/hardware/cores/shared_testing_core1.yaml
+++ b/stream/inputs/testing/hardware/cores/shared_testing_core1.yaml
@@ -27,8 +27,8 @@ memories:
     served_dimensions: [D1, D2]
 
 operational_array:
-  multiplier_energy: 0.04 # pJ
-  multiplier_area: 1 # unit
+  unit_energy: 0.04 # pJ
+  unit_area: 1 # unit
   dimensions: [D1, D2]
   sizes: [16, 16]
 

--- a/stream/inputs/testing/hardware/cores/shared_testing_core2.yaml
+++ b/stream/inputs/testing/hardware/cores/shared_testing_core2.yaml
@@ -27,8 +27,8 @@ memories:
     served_dimensions: [D1, D2]
 
 operational_array:
-  multiplier_energy: 0.04 # pJ
-  multiplier_area: 1 # unit
+  unit_energy: 0.04 # pJ
+  unit_area: 1 # unit
   dimensions: [D1, D2]
   sizes: [16, 16]
 

--- a/stream/inputs/testing/hardware/cores/testing_core1.yaml
+++ b/stream/inputs/testing/hardware/cores/testing_core1.yaml
@@ -136,8 +136,8 @@ memories:
 
 
 operational_array:
-  multiplier_energy: 0.04 # pJ
-  multiplier_area: 1 # unit
+  unit_energy: 0.04 # pJ
+  unit_area: 1 # unit
   dimensions: [D1, D2]
   sizes: [16, 16]
 

--- a/stream/inputs/testing/hardware/cores/testing_core2.yaml
+++ b/stream/inputs/testing/hardware/cores/testing_core2.yaml
@@ -136,8 +136,8 @@ memories:
 
 
 operational_array:
-  multiplier_energy: 0.04 # pJ
-  multiplier_area: 1 # unit
+  unit_energy: 0.04 # pJ
+  unit_area: 1 # unit
   dimensions: [D1, D2]
   sizes: [16, 16]
 

--- a/stream/parser/accelerator_validator.py
+++ b/stream/parser/accelerator_validator.py
@@ -5,8 +5,9 @@ from itertools import combinations
 from typing import Any
 
 from cerberus import Validator
-from zigzag.parser.accelerator_validator import AcceleratorValidator as CoreValidator
 from zigzag.utils import open_yaml
+
+from stream.parser.core_validator import CoreValidator
 
 logger = logging.getLogger(__name__)
 

--- a/stream/parser/core_validator.py
+++ b/stream/parser/core_validator.py
@@ -1,0 +1,15 @@
+from typing import Any
+
+from zigzag.parser.accelerator_validator import AcceleratorValidator as ZigZagAcceleratorValidator
+
+
+class CoreValidator(ZigZagAcceleratorValidator):
+    """Validates a single Stream accelerator core from a user-provided yaml file attribute."""
+
+    SCHEMA = ZigZagAcceleratorValidator.SCHEMA.copy()
+
+    # Add custom schema rules for Stream accelerator cores here
+
+    def __init__(self, data: Any):
+        """Initialize Validator object, assign schema and store normalize user-given data"""
+        super().__init__(data)


### PR DESCRIPTION
This PR adds a custom CoreValidator for Stream cores. This allows to easily add custom attributes to the core definition without requiring ZigZag changes.

Additionally, it updates the provided example input definitions to the required naming for zigzag 3.8.0.