### PR TITLE
Fix gemm

### DIFF
--- a/stream/parser/onnx/InPlaceAccumulator.py
+++ b/stream/parser/onnx/InPlaceAccumulator.py
@@ -1,0 +1,40 @@
+from stream.workload.computation.computation_node import ComputationNode
+from zigzag.parser.workload_factory import LayerNodeFactory
+from zigzag.parser.onnx.utils import get_onnx_tensor_type
+from stream.parser.onnx.simd import SimdParser 
+
+class InPlaceAccumulatorParser(SimdParser) :
+
+    def generate_node(self):
+        # Get the input and output activation shapes
+        accumulator_shape, grad_shape = InPlaceAccumulator_get_node_input_output_dimension_shapes(self.node, self.onnx_model)
+    
+        # From the ONNX node
+        node_data = self.get_layer_node_user_format(grad_shape, accumulator_shape)
+        node_factory = LayerNodeFactory(node_data, mapping_data=[])
+        node_attrs = node_factory.create_node_attr()
+
+        mapping = self.get_mapping_this_node()
+
+        return ComputationNode(
+            node_id=self.node_id,
+            node_name=self.node.name,
+            op_type="accumulate",
+            node_attr=node_attrs,
+            mapping_attr=mapping,
+        )
+
+
+def InPlaceAccumulator_get_node_input_output_dimension_shapes(node, model) :
+    # assumed it is the first input, don't see a way to otherwise know
+
+    accumulator_name = node.input[0]
+    accumulator_shape = get_onnx_tensor_type(accumulator_name, model).shape
+    grad_name = node.input[1]
+    grad_shape = get_onnx_tensor_type(grad_name, model).shape
+
+    # output_name = node.output[0]
+    # output_shape = get_onnx_tensor_type(output_name, model).shape
+
+    return accumulator_shape, grad_shape
+    

--- a/stream/parser/onnx/concat.py
+++ b/stream/parser/onnx/concat.py
@@ -16,14 +16,14 @@ class ConcatParser(OnnxOperatorParser):
 
         try:  # Try first one as constant input
             constant_tensor = get_onnx_tensor_type(input_1, self.onnx_model)
-            if constant_tensor.category != OnnxTensorCategory.HIDDEN or "constant" not in input_1.lower():
+            if constant_tensor.category not in[ OnnxTensorCategory.HIDDEN, OnnxTensorCategory.CONSTANT] :
                 raise ValueError
 
             constant_shape = tuple(constant_tensor.shape)
             variable_input_first = True
         except ValueError:  # Try second one as constant input
             constant_tensor = get_onnx_tensor_type(input_2, self.onnx_model)
-            if constant_tensor.category != OnnxTensorCategory.HIDDEN or "constant" not in input_2.lower():
+            if constant_tensor.category not in[ OnnxTensorCategory.HIDDEN, OnnxTensorCategory.CONSTANT] :
                 raise ValueError
 
             constant_shape = tuple(constant_tensor.shape)

--- a/stream/parser/onnx/convtranspose.py
+++ b/stream/parser/onnx/convtranspose.py
@@ -1,0 +1,141 @@
+import logging
+from math import ceil
+from typing import Any
+
+from zigzag.parser.onnx.utils import (
+    get_attribute_ints_with_name,
+    get_node_input_output_dimension_shapes,
+)
+from zigzag.parser.workload_factory import LayerNodeFactory
+
+from stream.parser.onnx.operator_parser import OnnxComputeOperatorParser
+from stream.workload.computation.computation_node import ComputationNode
+
+logger = logging.getLogger(__name__)
+
+
+class ConvTransposeParser(OnnxComputeOperatorParser):
+    """Parser for ONNX Conv and QLinearConv nodes into LayerNode."""
+
+    OP_TYPE = "convtranspose"
+
+    def get_layer_node_user_format(  # type: ignore
+        self,
+        kernel_shape: list[int],
+        strides: list[int],
+        dilations: list[int],
+        group_size: int,
+        padding: list[int],
+        ia_shape: list[int],
+        oa_shape: list[int],
+    ) -> dict[str, Any]:
+        """
+        Generate the necessary dictionary items required for the LayerNode creation.
+        """
+        # convert the data types to precisions based on the onnx definition
+
+        # Equation
+        data: dict[str, Any] = {}
+        data["id"] = self.node_id
+        data["name"] = f"Layer{self.node_id}"
+        data["operator_type"] = ConvTransposeParser.OP_TYPE
+        # IMPORTANT: If any of the input loops require padding, they should be defined as the rightmost dimensions in
+        # the equation. This is because we construct the dimensionality order and then add the padding to those last
+        # dimensions in the order
+        if group_size > 1:
+            data["equation"] = "O[b][g][k][oy][ox]+=W[g][c][fy][fx]*I[b][g][c][iy][ix]"
+        else:
+            data["equation"] = "O[b][g][k][oy][ox]+=W[k][c][fy][fx]*I[b][g][c][iy][ix]"
+
+        # Get dimension sizes from input parameters
+        assert ia_shape[0] == oa_shape[0], "Batch size is different for input and output activations."
+        B = oa_shape[0]
+        G = group_size
+        K = ceil(oa_shape[1] / G)
+        OX = oa_shape[3]
+        OY = oa_shape[2]
+        C = ceil(ia_shape[1] / G)
+        IX = ia_shape[3]
+        IY = ia_shape[2]
+        FX = kernel_shape[0]
+        FY = kernel_shape[1]
+        data["loop_dims"] = ["B", "K", "G", "IX", "IY", "C", "FX", "FY"]
+        data["loop_sizes"] = [B, K, G, IX, IY, C, FX, FY]
+
+        data["pr_loop_dims"] = ["OX", "OY"]
+        data["pr_loop_sizes"] = [OX, OY]
+        data["dimension_relations"] = [
+            f"ox={strides[0]}*ix+{dilations[0]}*fx",
+            f"oy={strides[1]}*iy+{dilations[1]}*fy",
+        ]
+        data["operand_precision"] = {"O": 16, "O_final": 8, "W": 8, "I": 8}
+
+        # Add information wrt how this conv node's input/output tensors
+        # are represented in the onnx model vs how they are represented in the equation above.
+        # Because onnx doesn't actually encode the group dimension in a separate dimension
+        # but instead keeps it as a "groups" parameter.
+        # Concretely, this entry contains for the I and O operand how the G + C/K should be converted
+        # to a single "CH" (channel) dimension.
+
+        # Add padding information
+        data["padding"] = [
+            [padding[0], padding[2]],
+            [padding[1], padding[3]],
+        ]
+
+        # Find the previous layer(s) that should be this node's parent(s)
+        node_inputs = self.node.input
+        assert len(node_inputs) >= 2, f"Conv should have at least two input names, but has: {node_inputs}."
+        (first_input_name, second_input_name) = node_inputs[:2]
+
+        source_list_I = [
+            src for (src, src_output_names) in self.nodes_outputs.items() if first_input_name in src_output_names
+        ]
+        source_list_W = [
+            src for (src, src_output_names) in self.nodes_outputs.items() if second_input_name in src_output_names
+        ]
+        assert len(source_list_I) <= 1
+        assert len(source_list_W) <= 1
+
+        source_I = source_list_I[0] if len(source_list_I) == 1 else self.node_id
+        source_W = source_list_W[0] if len(source_list_W) == 1 else self.node_id
+
+        data["operand_source"] = {
+            "I": source_I,
+            "W": source_W,
+        }
+
+        return data
+
+    def generate_node(self):
+        attrs = self.node.attribute
+        kernel_shape: list[int] = get_attribute_ints_with_name("kernel_shape", attrs, default=None)  # type:ignore
+        strides: list[int] = get_attribute_ints_with_name("strides", attrs, default=[1, 1])  # type:ignore
+        dilations: list[int] = get_attribute_ints_with_name("dilations", attrs, default=[1, 1])  # type:ignore
+        group_size: int = get_attribute_ints_with_name("group", attrs, default=1)  # type:ignore
+        padding: list[int] = get_attribute_ints_with_name("pads", attrs, default=[0, 0, 0, 0])  # type:ignore
+        # Get the input and output activation shapes
+        ia_dimension_shape, oa_dimension_shape = get_node_input_output_dimension_shapes(self.node, self.onnx_model)
+
+        node_data: dict[str, Any] = self.get_layer_node_user_format(
+            kernel_shape,
+            strides,
+            dilations,
+            group_size,
+            padding,
+            ia_dimension_shape,
+            oa_dimension_shape,
+        )
+
+        node_factory = LayerNodeFactory(node_data, mapping_data=None)
+        node_attrs = node_factory.create_node_attr()
+        mapping = self.get_mapping_this_node()
+
+        return ComputationNode(
+            node_id=self.node_id,
+            node_name=self.node.name,
+            node_attr=node_attrs,
+            mapping_attr=mapping,
+            op_type=ConvTransposeParser.OP_TYPE,
+            operand_tensor_reshape=None,
+        )

--- a/stream/parser/onnx/gemm.py
+++ b/stream/parser/onnx/gemm.py
@@ -2,9 +2,15 @@ import logging
 from typing import Generator
 
 from zigzag.parser.onnx.gemm_parser import GemmParser as GemmParserZigZag
+from zigzag.parser.onnx.utils import (
+    get_attribute_ints_with_name,
+    get_node_input_output_dimension_shapes,
+)
+from zigzag.parser.workload_factory import LayerNodeFactory
 
 from stream.parser.onnx.operator_parser import OnnxComputeOperatorParser
 from stream.workload.computation.computation_node import ComputationNode
+
 
 logger = logging.getLogger(__name__)
 
@@ -14,3 +20,27 @@ class GemmParser(GemmParserZigZag, OnnxComputeOperatorParser):
 
     def run(self) -> Generator[ComputationNode, None, None]:  # type: ignore
         yield self.generate_node()
+
+    def generate_node(self):
+        # Get the input and output activation shapes
+        input_shape, output_shape = get_node_input_output_dimension_shapes(self.node, self.onnx_model)
+        transpose_first_input = get_attribute_ints_with_name("transA", self.node.attribute, default=0)
+        if transpose_first_input:
+            assert len(input_shape) == 2, "Transpose only supported for GEMMs with two input dimensions"
+            input_shape = [input_shape[1], input_shape[0]]
+
+        logger.info("%s node name %s input shape %s output shape", self.node.name, input_shape, output_shape)
+        # From the ONNX node
+        node_data = self.get_layer_node_user_format(input_shape, output_shape)
+        node_factory = LayerNodeFactory(node_data, mapping_data=[])
+        node_attrs = node_factory.create_node_attr()
+
+        mapping = self.get_mapping_this_node()
+
+        return ComputationNode(
+            node_id=self.node_id,
+            node_name=self.node.name,
+            op_type=self.node.op_type,
+            node_attr=node_attrs,
+            mapping_attr=mapping,
+        )

--- a/stream/parser/onnx/model.py
+++ b/stream/parser/onnx/model.py
@@ -20,6 +20,11 @@ from stream.parser.onnx.reshape import ReshapeParser
 from stream.parser.onnx.simd import SimdParser
 from stream.parser.onnx.softmax import SoftmaxParser
 from stream.parser.onnx.transpose import TransposeParser
+from stream.parser.onnx.softmaxcrossentropy import SoftmaxCrossEntropyParser
+from stream.parser.onnx.softmaxcrossentropygrad import SoftmaxCrossEntropyGradParser
+from stream.parser.onnx.convtranspose import ConvTransposeParser
+from stream.parser.onnx.reducesum import ReduceSumParser
+from stream.parser.onnx.InPlaceAccumulator import InPlaceAccumulatorParser
 from stream.utils import get_onnx_input_shapes, has_asymmetric_input_data
 from stream.workload.mapping import InterCoreMappingAttributes
 from stream.workload.onnx_workload import ONNXWorkload
@@ -52,6 +57,12 @@ class ONNXModelParser:
         "Reshape": ReshapeParser,
         "Flatten": FlattenParser,
         "Concat": ConcatParser,
+        "SoftmaxCrossEntropyLoss" : SoftmaxCrossEntropyParser,
+        "SoftmaxCrossEntropyLossGrad": SoftmaxCrossEntropyGradParser,
+        "ConvTranspose": ConvTransposeParser,
+        "ReduceSum" :ReduceSumParser,
+        "InPlaceAccumulatorV2": InPlaceAccumulatorParser,
+        # "ConvGrad": ConvGradParser,
     }
 
     def __init__(

--- a/stream/parser/onnx/reducesum.py
+++ b/stream/parser/onnx/reducesum.py
@@ -1,0 +1,138 @@
+from typing import Any
+
+from zigzag.datatypes import Constants
+
+from stream.parser.onnx.operator_parser import OnnxComputeOperatorParser
+from stream.parser.onnx.reduce_1d import Reduce1DParser
+
+from zigzag.parser.onnx.utils import get_node_input_output_dimension_shapes
+from zigzag.parser.workload_factory import LayerNodeFactory
+from stream.workload.computation.computation_node import ComputationNode
+
+class ReduceSumParser(OnnxComputeOperatorParser):
+    # For now reduce over 4 axis to one
+
+    NODE_TYPES = ["sum", "sum", "sum"]
+    def run(self):
+        for node in self.get_nodes():
+            yield node
+
+    def get_layer_node_user_format(self, input_shape: list[int], output_shape: list[int]) -> dict[str, Any]:
+        """Not used for this class, but abstract base class requires instantiation anyway"""
+        ...
+
+    def get_nodes(self):
+        # Parse initial CNs
+        self.parse_into_subnodes()
+        # Give correct op type and name
+        self.set_nodes_name_and_type()
+        # Override dependencies
+        self.correct_nodes_operand_source()
+
+        return self.nodes
+    
+    def parse_into_subnodes(self) :
+        """Prase the base ONNX node multiple times into the different Computation Nodes.
+        The CNs that result from this operation have some incorrect properties regarding the graph structure
+        """
+        # parser_classes: list[type] = [Reduce1DParser, SoftmaxExpParser, Reduce1DParser, SoftmaxDivParser, SoftmaxCrossEntropySIMDParser, Reduce1DParser, SoftmaxCrossEntropyReduceParser]
+        parser_classes: list[type] = [Reduce4D3DParser, Reduce3D2DParser, Reduce2D1DParser]
+        node_ids = [self.node_id + i for i in range(3)]
+        parsers: list[OnnxComputeOperatorParser] = [
+            parser(
+                node_id=node_id,
+                node=self.node,
+                nodes_outputs=self.nodes_outputs,
+                onnx_model=self.onnx_model,
+                all_mappings=self.all_mappings,
+                accelerator=self.accelerator,
+            )
+            for parser, node_id in zip(parser_classes, node_ids)
+        ]
+        self.nodes = []
+        for parser in parsers :
+            for node in parser.run() :
+                self.nodes.append(node)
+        self.nodes = tuple(self.nodes)
+
+    def set_nodes_name_and_type(self) :
+        """Set the name and operator type of all Computation Nodes that stem from the base ONNX node"""
+        for node, node_type in zip(self.nodes, ReduceSumParser.NODE_TYPES):
+            node.type = node_type
+            node.name += f"-{node_type}/"
+    def correct_nodes_operand_source(self) :
+        """Correct the `input_operand_source` and `constant_operands` of all Computation Nodes that stem from the base
+        ONNX node"""
+        op_I = Constants.LAYER_OP_I
+        op_W = Constants.LAYER_OP_W
+        node_sum1, node_sum2, node_sum3 = self.nodes
+        id_sum1, id_sum2, id_sum3 = [node.id for node in self.nodes]
+        prev_node_id = node_sum1.input_operand_source[op_I]  # Node before Softmax
+
+        # Default after generation: input_operand_source = {op_I: prev_node_id} and constant_operands = [W]
+        node_sum1.input_operand_source = {op_I:prev_node_id}
+        node_sum2.input_operand_source = {op_I:id_sum1}
+        node_sum3.input_operand_source = {op_I:id_sum2}
+        
+class Reduce4D3DParser(Reduce1DParser) :
+    def generate_node(self):
+        # Get the input and output activation shapes
+        input_shape, output_shape = get_node_input_output_dimension_shapes(self.node, self.onnx_model)
+        reduced_input_shape = [input_shape[0], input_shape[1], input_shape[2], input_shape[3]]
+
+        # From the ONNX node
+        node_data = self.get_layer_node_user_format(reduced_input_shape, output_shape)
+        node_factory = LayerNodeFactory(node_data, mapping_data=[])
+        node_attrs = node_factory.create_node_attr()
+
+        mapping = self.get_mapping_this_node()
+
+        return ComputationNode(
+            node_id=self.node_id,
+            node_name=self.node.name,
+            op_type=self.node.op_type,
+            node_attr=node_attrs,
+            mapping_attr=mapping,
+        )
+
+class Reduce3D2DParser(Reduce1DParser) :
+    def generate_node(self):
+        # Get the input and output activation shapes
+        input_shape, output_shape = get_node_input_output_dimension_shapes(self.node, self.onnx_model)
+        reduced_input_shape = [input_shape[0], input_shape[1], input_shape[2]]
+
+        # From the ONNX node
+        node_data = self.get_layer_node_user_format(reduced_input_shape, output_shape)
+        node_factory = LayerNodeFactory(node_data, mapping_data=[])
+        node_attrs = node_factory.create_node_attr()
+
+        mapping = self.get_mapping_this_node()
+
+        return ComputationNode(
+            node_id=self.node_id,
+            node_name=self.node.name,
+            op_type=self.node.op_type,
+            node_attr=node_attrs,
+            mapping_attr=mapping,
+        )
+
+class Reduce2D1DParser(Reduce1DParser) :
+    def generate_node(self):
+        # Get the input and output activation shapes
+        input_shape, output_shape = get_node_input_output_dimension_shapes(self.node, self.onnx_model)
+        reduced_input_shape = [input_shape[0], input_shape[1]]
+
+        # From the ONNX node
+        node_data = self.get_layer_node_user_format(reduced_input_shape, output_shape)
+        node_factory = LayerNodeFactory(node_data, mapping_data=[])
+        node_attrs = node_factory.create_node_attr()
+
+        mapping = self.get_mapping_this_node()
+
+        return ComputationNode(
+            node_id=self.node_id,
+            node_name=self.node.name,
+            op_type=self.node.op_type,
+            node_attr=node_attrs,
+            mapping_attr=mapping,
+        )

--- a/stream/parser/onnx/softmaxcrossentropy.py
+++ b/stream/parser/onnx/softmaxcrossentropy.py
@@ -1,0 +1,158 @@
+from typing import Any
+
+from zigzag.datatypes import Constants
+
+from stream.workload.computation.computation_node import ComputationNode
+from zigzag.parser.workload_factory import LayerNodeFactory
+from zigzag.parser.onnx.utils import get_onnx_tensor_type
+from stream.parser.onnx.operator_parser import OnnxComputeOperatorParser
+from stream.parser.onnx.softmax import SoftmaxExpParser, SoftmaxDivParser
+from stream.parser.onnx.simd import SimdParser
+from stream.parser.onnx.reduce_1d import Reduce1DParser
+
+class SoftmaxCrossEntropyParser(OnnxComputeOperatorParser):
+    """
+    Parses the SoftmaxCrossEntropy Operator
+    attributes :
+        - ignore_index:int
+        - reduction:string (default mean), "none", "sum", "mean"
+    inputs: 
+        - scores
+        - labels
+        - weights (optional)
+    outputs :
+        - output
+        - log_prob(optional)
+    """
+
+    """Parses the Softmax operator. Softmax works on full rows and can be computed as follows:
+    (1) m <- max(row[0:L])
+    (2) e[0:L] <- exp(row[0:L] - m)
+    (3) s <- sum(e[0:L])
+    (4) r[0:L] <- e[0:L] / s
+    It is split up in four distinct computation nodes.
+    """
+    # NODE_TYPES = ["max", "exp", "sum", "div", "log", "sum", "reduce"]
+    NODE_TYPES = ["max", "exp", "sum", "div", "log"]
+
+    def run(self):
+        for node in self.get_nodes():
+            yield node
+
+    def get_layer_node_user_format(self, input_shape: list[int], output_shape: list[int]) -> dict[str, Any]:
+        """Not used for this class, but abstract base class requires instantiation anyway"""
+        ...
+
+    def get_nodes(self):
+        # Parse initial CNs
+        self.parse_into_subnodes()
+        # Give correct op type and name
+        self.set_nodes_name_and_type()
+        # Override dependencies
+        self.correct_nodes_operand_source()
+
+        return self.nodes
+    
+    def parse_into_subnodes(self):
+        """Prase the base ONNX node multiple times into the different Computation Nodes.
+        The CNs that result from this operation have some incorrect properties regarding the graph structure
+        """
+        # parser_classes: list[type] = [Reduce1DParser, SoftmaxExpParser, Reduce1DParser, SoftmaxDivParser, SoftmaxCrossEntropySIMDParser, Reduce1DParser, SoftmaxCrossEntropyReduceParser]
+        parser_classes: list[type] = [Reduce1DParser, SoftmaxExpParser, Reduce1DParser, SoftmaxDivParser, SoftmaxCrossEntropySIMDParser]
+        node_ids = [self.node_id + i for i in range(7)]
+        parsers: list[OnnxComputeOperatorParser] = [
+            parser(
+                node_id=node_id,
+                node=self.node,
+                nodes_outputs=self.nodes_outputs,
+                onnx_model=self.onnx_model,
+                all_mappings=self.all_mappings,
+                accelerator=self.accelerator,
+            )
+            for parser, node_id in zip(parser_classes, node_ids)
+        ]
+        self.nodes = []
+        for parser in parsers :
+            for node in parser.run() :
+                self.nodes.append(node)
+        self.nodes = tuple(self.nodes)
+
+    def set_nodes_name_and_type(self):
+        """Set the name and operator type of all Computation Nodes that stem from the base ONNX node"""
+        for node, node_type in zip(self.nodes, SoftmaxCrossEntropyParser.NODE_TYPES):
+            node.type = node_type
+            node.name += f"-{node_type}/"
+
+    def correct_nodes_operand_source(self):
+        """Correct the `input_operand_source` and `constant_operands` of all Computation Nodes that stem from the base
+        ONNX node"""
+        op_I = Constants.LAYER_OP_I
+        op_W = Constants.LAYER_OP_W
+        node_sfm_max, node_sfm_exp, node_sfm_sum, node_sfm_div, node_log = self.nodes
+        id_sfm_max, id_sfm_exp, id_sfm_sum, id_sfm_div, id_log = [node.id for node in self.nodes]
+        prev_node_id = node_sfm_max.input_operand_source[op_I]  # Node before Softmax
+
+        # Default after generation: input_operand_source = {op_I: prev_node_id} and constant_operands = [W]
+        node_sfm_exp.input_operand_source = {op_I: prev_node_id, op_W: id_sfm_max}
+        node_sfm_exp.constant_operands = []
+        node_sfm_sum.input_operand_source = {op_I: id_sfm_exp}
+        node_sfm_div.input_operand_source = {op_I: id_sfm_exp, op_W: id_sfm_sum}
+        node_sfm_div.constant_operands = []
+
+        # TODO: fix constant operands for added nodes
+        node_log.input_operand_source = {op_I: id_sfm_div}
+        node_log.constant_operands = []
+        
+class SoftmaxCrossEntropySIMDParser(SimdParser) :
+    def generate_node(self):
+        # Get the input and output activation shapes
+        scores_shape, labels_shape, output_shape, logprob_shape = softmaxcrossentropy_get_node_input_output_dimension_shapes(self.node, self.onnx_model)
+
+        # From the ONNX node
+        node_data = self.get_layer_node_user_format(scores_shape, scores_shape)
+        node_factory = LayerNodeFactory(node_data, mapping_data=[])
+        node_attrs = node_factory.create_node_attr()
+
+        mapping = self.get_mapping_this_node()
+
+        return ComputationNode(
+            node_id=self.node_id,
+            node_name=self.node.name,
+            op_type=self.node.op_type,
+            node_attr=node_attrs,
+            mapping_attr=mapping,
+        )
+
+class SoftmaxCrossEntropyReduceParser(Reduce1DParser) :
+    def generate_node(self):
+        # Get the input and output activation shapes
+        scores_shape, labels_shape, output_shape, logprob_shape = softmaxcrossentropy_get_node_input_output_dimension_shapes(self.node, self.onnx_model)
+
+        # From the ONNX node
+        node_data = self.get_layer_node_user_format(scores_shape, scores_shape)
+        node_factory = LayerNodeFactory(node_data, mapping_data=[])
+        node_attrs = node_factory.create_node_attr()
+
+        mapping = self.get_mapping_this_node()
+
+        return ComputationNode(
+            node_id=self.node_id,
+            node_name=self.node.name,
+            op_type=self.node.op_type,
+            node_attr=node_attrs,
+            mapping_attr=mapping,
+        )
+
+def softmaxcrossentropy_get_node_input_output_dimension_shapes(node, model) :
+    # assumed it is the first input, don't see a way to otherwise know
+
+    scores_name = node.input[0]
+    scores_shape = get_onnx_tensor_type(scores_name, model).shape
+    labels_name = node.input[1]
+    labels_shape = get_onnx_tensor_type(labels_name, model).shape
+
+    output_name = node.output[0]
+    output_shape = get_onnx_tensor_type(output_name, model).shape
+    logprob_name = node.output[1]
+    logprob_shape = get_onnx_tensor_type(logprob_name, model).shape
+    return scores_shape, labels_shape, output_shape, logprob_shape

--- a/stream/parser/onnx/softmaxcrossentropygrad.py
+++ b/stream/parser/onnx/softmaxcrossentropygrad.py
@@ -1,0 +1,42 @@
+from stream.workload.computation.computation_node import ComputationNode
+from zigzag.parser.workload_factory import LayerNodeFactory
+from zigzag.parser.onnx.utils import get_onnx_tensor_type
+from stream.parser.onnx.simd import SimdParser
+
+class SoftmaxCrossEntropyGradParser(SimdParser):
+    # Modify SIMD Parser as it is the same operation
+
+    def generate_node(self):
+        # Get the input and output activation shapes
+        grad_shape, logprob_shape, labels_shape = softmaxcrossentropygrad_get_node_input_output_dimension_shapes(self.node, self.onnx_model)
+
+        # From the ONNX node
+        node_data = self.get_layer_node_user_format(logprob_shape, logprob_shape)
+        node_factory = LayerNodeFactory(node_data, mapping_data=[])
+        node_attrs = node_factory.create_node_attr()
+
+        mapping = self.get_mapping_this_node()
+
+        return ComputationNode(
+            node_id=self.node_id,
+            node_name=self.node.name,
+            op_type="add",
+            node_attr=node_attrs,
+            mapping_attr=mapping,
+        )
+
+def softmaxcrossentropygrad_get_node_input_output_dimension_shapes(node, model) :
+    # assumed it is the first input, don't see a way to otherwise know
+
+    grad_name = node.input[0]
+    grad_shape = get_onnx_tensor_type(grad_name, model).shape
+    logprob_name = node.input[1]
+    logprob_shape = get_onnx_tensor_type(logprob_name, model).shape
+    labels_name = node.input[2]
+    labels_shape = get_onnx_tensor_type(labels_name, model).shape
+
+    # output_name = node.output[0]
+    # output_shape = get_onnx_tensor_type(output_name, model).shape
+
+    return grad_shape, logprob_shape, labels_shape
+    

--- a/stream/workload/computation/computation_node.py
+++ b/stream/workload/computation/computation_node.py
@@ -48,6 +48,12 @@ class ComputationNode(LayerNode, Node):
         "relu": [LayerDim("K")],
         "gelu": [LayerDim("K")],
         "silu": [LayerDim("K")],
+        "softmaxcrossentropyloss": [LayerDim("K")],
+        "log":[LayerDim("K")],
+        "reduce":[LayerDim("K")],
+        "reducesum":[LayerDim("K")],
+        "convtranspose":[LayerDim("IY"), LayerDim("IX")],
+        "accumulate": [LayerDim("K")]
     }  # TODO default to "K" ?
 
     def __init__(
@@ -150,8 +156,20 @@ class ComputationNode(LayerNode, Node):
                 LayerOperand("I"): (size_B, -1, size_IX, size_IY),
                 LayerOperand("O"): (size_B, -1, size_OX, size_OY),
             }
-        except KeyError:
-            return None
+        except KeyError as e:
+            try:
+                size_B = self.layer_dim_sizes[LayerDim("B")]
+                size_IX = self.layer_dim_sizes[LayerDim("IX")]
+                size_IY = self.layer_dim_sizes[LayerDim("IY")]
+                size_OX = self.pr_layer_dim_sizes[LayerDim("OX")]
+                size_OY = self.pr_layer_dim_sizes[LayerDim("OY")]
+                return {
+                    LayerOperand("I"): (size_B, -1, size_IX, size_IY),
+                    LayerOperand("O"): (size_B, -1, size_OX, size_OY),
+                }
+            except KeyError as e:
+                
+                return None
 
     @property
     def short_name(self) -> str:


### PR DESCRIPTION
This PR is related to this issue https://github.com/KULeuven-MICAS/stream/issues/73

If the TranposeA attribute of the GEMM operator is set, then the operator is not parsed correctly, causing an error. 
This PR reuseqs the generate_node method of the GemmParserZigZag operator. 

Another approach could be done by entirely reimplementing the GEMM operator in Stream using the ZigZag definition.