### PR TITLE
Update input hardware definition

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -3,7 +3,7 @@ site_url: https://kuleuven-micas.github.io/stream/
 repo_url: https://github.com/KULeuven-MICAS/stream
 repo_name: KULeuven-MICAS/stream
 docs_dir: source
-site_dir: ../site
+site_dir: site
 edit_uri: edit/main/docs/
 
 theme:

--- a/stream/api.py
+++ b/stream/api.py
@@ -3,6 +3,7 @@ import os
 from typing import Literal
 
 import gurobipy as gp
+from onnx import ModelProto
 from zigzag.mapping.temporal_mapping import TemporalMappingType
 from zigzag.utils import pickle_load, pickle_save
 
@@ -28,7 +29,7 @@ def _sanity_check_inputs(
     hardware: str, workload: str, mapping: str, mode: Literal["lbl"] | Literal["fused"], output_path: str
 ):
     assert os.path.exists(hardware), f"Hardware file {hardware} does not exist"
-    assert os.path.exists(workload), f"Workload file {workload} does not exist"
+    assert isinstance(workload, ModelProto) or os.path.exists(workload), f"Workload file {workload} does not exist"
     assert os.path.exists(mapping), f"Mapping file {mapping} does not exist"
     assert mode in ["lbl", "fused"], "Mode must be either 'lbl' or 'fused'"
     if not os.path.exists(output_path):

--- a/stream/hardware/architecture/core.py
+++ b/stream/hardware/architecture/core.py
@@ -1,8 +1,14 @@
+from typing import Any
+
 from zigzag.datatypes import MemoryOperand
 from zigzag.hardware.architecture.accelerator import Accelerator as ZigZagCore
 
 
 class Core(ZigZagCore):
+    def __init__(self, args: Any):
+        super().__init__(**args)
+        self.type = "compute"  # default type for a core
+
     def __eq__(self, other: object) -> bool:
         return (
             isinstance(other, Core)

--- a/stream/inputs/examples/hardware/cores/eyeriss_like.yaml
+++ b/stream/inputs/examples/hardware/cores/eyeriss_like.yaml
@@ -1,4 +1,5 @@
 name: eyeriss_like
+type: compute
 
 memories:
   rf_64B_A:

--- a/stream/inputs/examples/hardware/cores/fusemax_array.yaml
+++ b/stream/inputs/examples/hardware/cores/fusemax_array.yaml
@@ -1,4 +1,5 @@
 name: generic_array
+type: compute
 
 memories:
   rf_I:

--- a/stream/inputs/examples/hardware/cores/fusemax_dram.yaml
+++ b/stream/inputs/examples/hardware/cores/fusemax_dram.yaml
@@ -1,4 +1,5 @@
 name: offchip
+type: compute
 
 memories:
   dram:

--- a/stream/inputs/examples/hardware/cores/fusemax_vec.yaml
+++ b/stream/inputs/examples/hardware/cores/fusemax_vec.yaml
@@ -1,4 +1,5 @@
 name: vec
+type: compute
 
 memories:
   rf_I:

--- a/stream/inputs/examples/hardware/cores/meta_prototype.yaml
+++ b/stream/inputs/examples/hardware/cores/meta_prototype.yaml
@@ -1,4 +1,5 @@
 name: meta_prototype
+type: compute
 
 memories:
   rf_1B:

--- a/stream/inputs/examples/hardware/cores/offchip.yaml
+++ b/stream/inputs/examples/hardware/cores/offchip.yaml
@@ -1,4 +1,5 @@
 name: offchip
+type: memory
 
 memories:
   dram:

--- a/stream/inputs/examples/hardware/cores/pooling.yaml
+++ b/stream/inputs/examples/hardware/cores/pooling.yaml
@@ -1,4 +1,5 @@
 name: pooling
+type: compute
 
 memories:
   sram_128KB:

--- a/stream/inputs/examples/hardware/cores/simba_chiplet.yaml
+++ b/stream/inputs/examples/hardware/cores/simba_chiplet.yaml
@@ -1,4 +1,5 @@
 name: simba_chiplet
+type: compute
 
 memories:
 

--- a/stream/inputs/examples/hardware/cores/simba_offchip.yaml
+++ b/stream/inputs/examples/hardware/cores/simba_offchip.yaml
@@ -1,4 +1,5 @@
 name: simba_offchip
+type: compute
 
 memories:
   dram:

--- a/stream/inputs/examples/hardware/cores/simd.yaml
+++ b/stream/inputs/examples/hardware/cores/simd.yaml
@@ -1,4 +1,5 @@
 name: pooling
+type: compute
 
 memories:
   sram_128KB_2rw:

--- a/stream/inputs/examples/hardware/cores/tpu_like.yaml
+++ b/stream/inputs/examples/hardware/cores/tpu_like.yaml
@@ -1,4 +1,5 @@
 name: tpu_like
+type: compute
 
 memories:
   rf_128B:

--- a/stream/inputs/examples/hardware/eyeriss_like_dual_core.yaml
+++ b/stream/inputs/examples/hardware/eyeriss_like_dual_core.yaml
@@ -1,17 +1,31 @@
+# Two Eyeriss-like compute cores with pooling, SIMD and a DRAM controller
 name: eyeriss_like_dual_core
+
 cores:
-  0: eyeriss_like.yaml
-  1: eyeriss_like.yaml
-  2: pooling.yaml
-  3: simd.yaml
-offchip_core: offchip.yaml
+  0: eyeriss_like.yaml   # compute A
+  1: eyeriss_like.yaml   # compute B
+  2: pooling.yaml        # pooling engine
+  3: simd.yaml           # SIMD unit
+  4: offchip.yaml        # DRAM controller
+
+offchip_core_id: 4       # core that fronts external memory
+unit_energy_cost: 0      # default energy per transferred word
 
 core_connectivity:
-  - 0, 1
-  - 0, 2
-  - 0, 3
-  - 1, 2
-  - 1, 3
+  # ─── direct link between the two compute cores ───
+  - type: link
+    cores: [0, 1]
+    bandwidth: 32
 
-bandwidth: 32
-unit_energy_cost: 0
+  # ─── pooling core connected to each compute core ───
+  - {type: link, cores: [0, 2], bandwidth: 32}
+  - {type: link, cores: [1, 2], bandwidth: 32}
+
+  # ─── SIMD core connected to each compute core ───
+  - {type: link, cores: [0, 3], bandwidth: 32}
+  - {type: link, cores: [1, 3], bandwidth: 32}
+
+  # ─── shared bus to off-chip DRAM ───
+  - type: bus
+    cores: [0, 1, 2, 3, 4]   # all on-chip cores + controller
+    bandwidth: 128           # wider than point-to-point links

--- a/stream/inputs/examples/hardware/eyeriss_like_quad_core.yaml
+++ b/stream/inputs/examples/hardware/eyeriss_like_quad_core.yaml
@@ -1,29 +1,46 @@
+# Four Eyeriss-like compute cores with pooling, SIMD and an off-chip DRAM controller
 name: eyeriss_like_quad_core
+
 cores:
-  0: eyeriss_like.yaml
-  1: eyeriss_like.yaml
-  2: eyeriss_like.yaml
-  3: eyeriss_like.yaml
-  4: pooling.yaml
-  5: simd.yaml
-offchip_core: offchip.yaml
+  0: eyeriss_like.yaml   # compute A
+  1: eyeriss_like.yaml   # compute B
+  2: eyeriss_like.yaml   # compute C
+  3: eyeriss_like.yaml   # compute D
+  4: pooling.yaml        # pooling helper
+  5: simd.yaml           # SIMD helper
+  6: offchip.yaml        # DRAM controller
+
+offchip_core_id: 6       # core that fronts external memory
+unit_energy_cost: 0      # default energy per transferred word
 
 core_connectivity:
-  # 2D mesh
-  - 0, 1
-  - 1, 2
-  - 2, 3
-  - 3, 1
-  # Connect pooling core to all
-  - 0, 4
-  - 1, 4
-  - 2, 4
-  - 3, 4
-  # Connect SIMD to all
-  - 0, 5
-  - 1, 5
-  - 2, 5
-  - 3, 5
+  # ───── 2-D mesh links among compute cores ─────
+  - type: link
+    cores: [0, 1]
+    bandwidth: 32
+  - type: link
+    cores: [1, 2]
+    bandwidth: 32
+  - type: link
+    cores: [2, 3]
+    bandwidth: 32
+  - type: link            # extra link as in original spec
+    cores: [3, 1]
+    bandwidth: 32
 
-bandwidth: 32
-unit_energy_cost: 0
+  # ───── Pooling core connected to every compute core ─────
+  - {type: link, cores: [0, 4], bandwidth: 32}
+  - {type: link, cores: [1, 4], bandwidth: 32}
+  - {type: link, cores: [2, 4], bandwidth: 32}
+  - {type: link, cores: [3, 4], bandwidth: 32}
+
+  # ───── SIMD core connected to every compute core ─────
+  - {type: link, cores: [0, 5], bandwidth: 32}
+  - {type: link, cores: [1, 5], bandwidth: 32}
+  - {type: link, cores: [2, 5], bandwidth: 32}
+  - {type: link, cores: [3, 5], bandwidth: 32}
+
+  # ───── Shared bus to off-chip DRAM ─────
+  - type: bus
+    cores: [0, 1, 2, 3, 4, 5, 6]   # all on-chip cores + controller
+    bandwidth: 128                 # wider than on-chip point-to-point links

--- a/stream/inputs/examples/hardware/eyeriss_like_single_core.yaml
+++ b/stream/inputs/examples/hardware/eyeriss_like_single_core.yaml
@@ -1,13 +1,25 @@
+# Eyeriss-like single compute core with dedicated pooling, SIMD and an off-chip DRAM controller
 name: eyeriss_like_single_core
+
 cores:
-  0: eyeriss_like.yaml
-  1: pooling.yaml
-  2: simd.yaml
-offchip_core: offchip.yaml
+  0: eyeriss_like.yaml   # main compute core
+  1: pooling.yaml        # pooling engine
+  2: simd.yaml           # SIMD/vector unit
+  3: offchip.yaml        # DRAM controller
+
+offchip_core_id: 3       # which core fronts external memory
+unit_energy_cost: 0      # default energy per transferred word
 
 core_connectivity:
-  - 0, 1
-  - 0, 2
+  # ─── On-chip links from compute core to its helpers ───
+  - type: link
+    cores: [0, 1]        # compute ↔ pooling
+    bandwidth: 32
+  - type: link
+    cores: [0, 2]        # compute ↔ SIMD
+    bandwidth: 32
 
-bandwidth: 32
-unit_energy_cost: 0
+  # ─── Shared bus to off-chip memory (all cores + controller) ───
+  - type: bus
+    cores: [0, 1, 2, 3]
+    bandwidth: 64        # wider than the point-to-point links

--- a/stream/inputs/examples/hardware/fusemax.yaml
+++ b/stream/inputs/examples/hardware/fusemax.yaml
@@ -1,14 +1,20 @@
+# Two FuseMax cores sharing a top-level on-chip memory, plus an explicit DRAM controller
 name: quad_core
-cores:
-  0: stream/inputs/examples/hardware/cores/fusemax_array.yaml
-  1: stream/inputs/examples/hardware/cores/fusemax_vec.yaml
-offchip_core: stream/inputs/examples/hardware/cores/fusemax_dram.yaml
 
-core_connectivity: []
+cores:
+  0: stream/inputs/examples/hardware/cores/fusemax_array.yaml   # main array core
+  1: stream/inputs/examples/hardware/cores/fusemax_vec.yaml     # SIMD/vector core
+  2: stream/inputs/examples/hardware/cores/fusemax_dram.yaml    # off-chip DRAM controller
+
+offchip_core_id: 2          # core that fronts external memory
+unit_energy_cost: 512       # default energy per transferred word
+
+core_connectivity:
+  # Shared bus that links both compute cores to the DRAM controller
+  - type: bus
+    cores: [0, 1, 2]
+    bandwidth: 512
 
 core_memory_sharing:
-  # Link all simd units to main cores
+  # The SIMD core re-uses the array core’s top-level memory, so no direct link is listed above
   - 0, 1
-
-bandwidth: 512
-unit_energy_cost: 512

--- a/stream/inputs/examples/hardware/meta_prototype_dual_core_simd_offchip.yaml
+++ b/stream/inputs/examples/hardware/meta_prototype_dual_core_simd_offchip.yaml
@@ -1,17 +1,39 @@
+# Two meta-prototype compute cores plus pooling, SIMD and an off-chip DRAM controller
 name: meta-proto-2-core-with-pooling-and-offchip-cores
+
 cores:
-  0: meta_prototype.yaml
-  1: meta_prototype.yaml
-  2: pooling.yaml
-  3: simd.yaml
-offchip_core: offchip.yaml
+  0: meta_prototype.yaml   # compute-core A
+  1: meta_prototype.yaml   # compute-core B
+  2: pooling.yaml          # pooling engine
+  3: simd.yaml             # SIMD unit
+  4: offchip.yaml          # DRAM controller
+
+offchip_core_id: 4         # which core fronts external memory
+unit_energy_cost: 0        # default energy per transferred word
 
 core_connectivity:
-  - 0, 1
-  - 0, 2
-  - 0, 3
-  - 1, 2
-  - 1, 3
+  # ─── direct link between the two compute cores ───
+  - type: link
+    cores: [0, 1]
+    bandwidth: 64
 
-bandwidth: 64
-unit_energy_cost: 0
+  # ─── pooling core connected to each compute core ───
+  - type: link
+    cores: [0, 2]
+    bandwidth: 64
+  - type: link
+    cores: [1, 2]
+    bandwidth: 64
+
+  # ─── SIMD core connected to each compute core ───
+  - type: link
+    cores: [0, 3]
+    bandwidth: 64
+  - type: link
+    cores: [1, 3]
+    bandwidth: 64
+
+  # ─── shared bus to off-chip memory (all on-chip cores + controller) ───
+  - type: bus
+    cores: [0, 1, 2, 3, 4]
+    bandwidth: 128        # wider than on-chip point-to-point links

--- a/stream/inputs/examples/hardware/simba.yaml
+++ b/stream/inputs/examples/hardware/simba.yaml
@@ -1,17 +1,17 @@
+# 6 × 6 SIMBA chiplet mesh plus a package-level DRAM controller
 name: simba_package
 
-cores:
-  # 36 simba chiplets
-  0: simba_chiplet.yaml
-  1: simba_chiplet.yaml
-  2: simba_chiplet.yaml
-  3: simba_chiplet.yaml
-  4: simba_chiplet.yaml
-  5: simba_chiplet.yaml
-  6: simba_chiplet.yaml
-  7: simba_chiplet.yaml
-  8: simba_chiplet.yaml
-  9: simba_chiplet.yaml
+cores:     # id → YAML description
+  0:  simba_chiplet.yaml
+  1:  simba_chiplet.yaml
+  2:  simba_chiplet.yaml
+  3:  simba_chiplet.yaml
+  4:  simba_chiplet.yaml
+  5:  simba_chiplet.yaml
+  6:  simba_chiplet.yaml
+  7:  simba_chiplet.yaml
+  8:  simba_chiplet.yaml
+  9:  simba_chiplet.yaml
   10: simba_chiplet.yaml
   11: simba_chiplet.yaml
   12: simba_chiplet.yaml
@@ -38,70 +38,78 @@ cores:
   33: simba_chiplet.yaml
   34: simba_chiplet.yaml
   35: simba_chiplet.yaml
-offchip_core: simba_offchip.yaml
+  36: simba_offchip.yaml      # DRAM controller
+
+offchip_core_id: 36           # external-memory interface
+unit_energy_cost: 0           # global default
 
 core_connectivity:
-  # 2D mesh
-  - 0, 1
-  - 0, 6
-  - 1, 2
-  - 1, 7
-  - 2, 3
-  - 2, 8
-  - 3, 4
-  - 3, 9
-  - 4, 5
-  - 4, 10
-  - 5, 11
-  - 6, 7
-  - 6, 12
-  - 7, 8
-  - 7, 13
-  - 8, 9
-  - 8, 14
-  - 9, 10
-  - 9, 15
-  - 10, 11
-  - 10, 16
-  - 11, 17
-  - 12, 13
-  - 12, 18
-  - 13, 14
-  - 13, 19
-  - 14, 15
-  - 14, 20
-  - 15, 16
-  - 15, 21
-  - 16, 17
-  - 16, 22
-  - 17, 23
-  - 18, 19
-  - 18, 24
-  - 19, 20
-  - 19, 25
-  - 20, 21
-  - 20, 26
-  - 21, 22
-  - 21, 27
-  - 22, 23
-  - 22, 28
-  - 23, 29
-  - 24, 25
-  - 24, 30
-  - 25, 26
-  - 25, 31
-  - 26, 27
-  - 26, 32
-  - 27, 28
-  - 27, 33
-  - 28, 29
-  - 28, 34
-  - 29, 35
-  - 30, 31
-  - 31, 32
-  - 32, 33
-  - 33, 34
-  - 34, 35
+  # ───────── 2-D mesh links (bandwidth 32 each) ─────────
+  - {type: link, cores: [0, 1],  bandwidth: 32}
+  - {type: link, cores: [0, 6],  bandwidth: 32}
+  - {type: link, cores: [1, 2],  bandwidth: 32}
+  - {type: link, cores: [1, 7],  bandwidth: 32}
+  - {type: link, cores: [2, 3],  bandwidth: 32}
+  - {type: link, cores: [2, 8],  bandwidth: 32}
+  - {type: link, cores: [3, 4],  bandwidth: 32}
+  - {type: link, cores: [3, 9],  bandwidth: 32}
+  - {type: link, cores: [4, 5],  bandwidth: 32}
+  - {type: link, cores: [4, 10], bandwidth: 32}
+  - {type: link, cores: [5, 11], bandwidth: 32}
+  - {type: link, cores: [6, 7],  bandwidth: 32}
+  - {type: link, cores: [6, 12], bandwidth: 32}
+  - {type: link, cores: [7, 8],  bandwidth: 32}
+  - {type: link, cores: [7, 13], bandwidth: 32}
+  - {type: link, cores: [8, 9],  bandwidth: 32}
+  - {type: link, cores: [8, 14], bandwidth: 32}
+  - {type: link, cores: [9, 10], bandwidth: 32}
+  - {type: link, cores: [9, 15], bandwidth: 32}
+  - {type: link, cores: [10,11], bandwidth: 32}
+  - {type: link, cores: [10,16], bandwidth: 32}
+  - {type: link, cores: [11,17], bandwidth: 32}
+  - {type: link, cores: [12,13], bandwidth: 32}
+  - {type: link, cores: [12,18], bandwidth: 32}
+  - {type: link, cores: [13,14], bandwidth: 32}
+  - {type: link, cores: [13,19], bandwidth: 32}
+  - {type: link, cores: [14,15], bandwidth: 32}
+  - {type: link, cores: [14,20], bandwidth: 32}
+  - {type: link, cores: [15,16], bandwidth: 32}
+  - {type: link, cores: [15,21], bandwidth: 32}
+  - {type: link, cores: [16,17], bandwidth: 32}
+  - {type: link, cores: [16,22], bandwidth: 32}
+  - {type: link, cores: [17,23], bandwidth: 32}
+  - {type: link, cores: [18,19], bandwidth: 32}
+  - {type: link, cores: [18,24], bandwidth: 32}
+  - {type: link, cores: [19,20], bandwidth: 32}
+  - {type: link, cores: [19,25], bandwidth: 32}
+  - {type: link, cores: [20,21], bandwidth: 32}
+  - {type: link, cores: [20,26], bandwidth: 32}
+  - {type: link, cores: [21,22], bandwidth: 32}
+  - {type: link, cores: [21,27], bandwidth: 32}
+  - {type: link, cores: [22,23], bandwidth: 32}
+  - {type: link, cores: [22,28], bandwidth: 32}
+  - {type: link, cores: [23,29], bandwidth: 32}
+  - {type: link, cores: [24,25], bandwidth: 32}
+  - {type: link, cores: [24,30], bandwidth: 32}
+  - {type: link, cores: [25,26], bandwidth: 32}
+  - {type: link, cores: [25,31], bandwidth: 32}
+  - {type: link, cores: [26,27], bandwidth: 32}
+  - {type: link, cores: [26,32], bandwidth: 32}
+  - {type: link, cores: [27,28], bandwidth: 32}
+  - {type: link, cores: [27,33], bandwidth: 32}
+  - {type: link, cores: [28,29], bandwidth: 32}
+  - {type: link, cores: [28,34], bandwidth: 32}
+  - {type: link, cores: [29,35], bandwidth: 32}
+  - {type: link, cores: [30,31], bandwidth: 32}
+  - {type: link, cores: [31,32], bandwidth: 32}
+  - {type: link, cores: [32,33], bandwidth: 32}
+  - {type: link, cores: [33,34], bandwidth: 32}
+  - {type: link, cores: [34,35], bandwidth: 32}
 
-bandwidth: 32
-unit_energy_cost: 0
+  # ───────── Shared off-chip bus ─────────
+  - type: bus
+    cores: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
+            10,11,12,13,14,15,16,17,18,19,
+            20,21,22,23,24,25,26,27,28,29,
+            30,31,32,33,34,35,36]     # all chiplets + DRAM ctrl
+    bandwidth: 256                    # wider than on-chip links

--- a/stream/inputs/examples/hardware/simba_small.yaml
+++ b/stream/inputs/examples/hardware/simba_small.yaml
@@ -1,19 +1,32 @@
+# 2 × 2 SIMBA mesh with an explicit off-chip DRAM controller
 name: simba_package_small
 
 cores:
-  # 4 simba chiplets
-  0: simba_chiplet.yaml
-  1: simba_chiplet.yaml
-  2: simba_chiplet.yaml
-  3: simba_chiplet.yaml
-offchip_core: simba_offchip.yaml
+  0: simba_chiplet.yaml   # chiplet A
+  1: simba_chiplet.yaml   # chiplet B
+  2: simba_chiplet.yaml   # chiplet C
+  3: simba_chiplet.yaml   # chiplet D
+  4: simba_offchip.yaml   # package-level DRAM controller
+
+offchip_core_id: 4        # core that fronts external memory
+unit_energy_cost: 0       # default energy per transferred word
 
 core_connectivity:
-  # 2D mesh
-  - 0, 1
-  - 0, 2
-  - 1, 3
-  - 2, 3
+  # ───── 2-D mesh links between chiplets ─────
+  - type: link
+    cores: [0, 1]
+    bandwidth: 32
+  - type: link
+    cores: [0, 2]
+    bandwidth: 32
+  - type: link
+    cores: [1, 3]
+    bandwidth: 32
+  - type: link
+    cores: [2, 3]
+    bandwidth: 32
 
-bandwidth: 32
-unit_energy_cost: 0
+  # ───── Shared bus to off-chip memory ─────
+  - type: bus
+    cores: [0, 1, 2, 3, 4]   # all chiplets + DRAM controller
+    bandwidth: 128           # wider than on-chip links

--- a/stream/inputs/examples/hardware/tpu_like_quad_core.yaml
+++ b/stream/inputs/examples/hardware/tpu_like_quad_core.yaml
@@ -1,30 +1,62 @@
+# Four TPU-like compute cores + pooling, SIMD and off-chip DRAM controller
 name: tpu_like_quad_core
 
 cores:
-  0: tpu_like.yaml
-  1: tpu_like.yaml
-  2: tpu_like.yaml
-  3: tpu_like.yaml
-  4: pooling.yaml
-  5: simd.yaml
-offchip_core: offchip.yaml
+  0: tpu_like.yaml   # compute A
+  1: tpu_like.yaml   # compute B
+  2: tpu_like.yaml   # compute C
+  3: tpu_like.yaml   # compute D
+  4: pooling.yaml    # pooling engine
+  5: simd.yaml       # SIMD unit
+  6: offchip.yaml    # DRAM controller
+
+offchip_core_id: 6     # core that fronts external memory
+unit_energy_cost: 0    # default energy for core_connectivity
 
 core_connectivity:
-  # 2D mesh
-  - 0, 1
-  - 1, 2
-  - 2, 3
-  - 3, 0
-  # Connect pooling core to all
-  - 0, 4
-  - 1, 4
-  - 2, 4
-  - 3, 4
-  # Connect SIMD to all
-  - 0, 5
-  - 1, 5
-  - 2, 5
-  - 3, 5
+  # ───── 2-D mesh among the four compute cores ─────
+  - type: link
+    cores: [0, 1]
+    bandwidth: 32
+  - type: link
+    cores: [1, 2]
+    bandwidth: 32
+  - type: link
+    cores: [2, 3]
+    bandwidth: 32
+  - type: link
+    cores: [3, 0]
+    bandwidth: 32
 
-bandwidth: 32
-unit_energy_cost: 0
+  # ───── Pooling core connected to every compute core ─────
+  - type: link
+    cores: [0, 4]
+    bandwidth: 32
+  - type: link
+    cores: [1, 4]
+    bandwidth: 32
+  - type: link
+    cores: [2, 4]
+    bandwidth: 32
+  - type: link
+    cores: [3, 4]
+    bandwidth: 32
+
+  # ───── SIMD core connected to every compute core ─────
+  - type: link
+    cores: [0, 5]
+    bandwidth: 32
+  - type: link
+    cores: [1, 5]
+    bandwidth: 32
+  - type: link
+    cores: [2, 5]
+    bandwidth: 32
+  - type: link
+    cores: [3, 5]
+    bandwidth: 32
+
+  # ───── Shared bus to off-chip memory (all cores ↔ DRAM) ─────
+  - type: bus
+    cores: [0, 1, 2, 3, 4, 5, 6]
+    bandwidth: 128        # wider than on-chip point-to-point links

--- a/stream/inputs/examples/mapping/tpu_like_quad_core.yaml
+++ b/stream/inputs/examples/mapping/tpu_like_quad_core.yaml
@@ -17,7 +17,7 @@
   intra_core_tiling:
     - D, all
   inter_core_tiling:
-    - H, *
+    - K, *
 
 - name: Pool
   core_allocation: [4]

--- a/stream/inputs/testing/hardware/cores/offchip.yaml
+++ b/stream/inputs/testing/hardware/cores/offchip.yaml
@@ -1,4 +1,5 @@
 name: offchip
+type: memory
 
 memories:
   dram:

--- a/stream/inputs/testing/hardware/cores/pooling.yaml
+++ b/stream/inputs/testing/hardware/cores/pooling.yaml
@@ -1,4 +1,5 @@
 name: pooling
+type: compute
 
 memories:
   sram_128KB:

--- a/stream/inputs/testing/hardware/cores/shared_testing_core1.yaml
+++ b/stream/inputs/testing/hardware/cores/shared_testing_core1.yaml
@@ -1,4 +1,5 @@
 name: shared_testing_core1
+type: compute
 
 memories:
   sram_64KB:

--- a/stream/inputs/testing/hardware/cores/shared_testing_core2.yaml
+++ b/stream/inputs/testing/hardware/cores/shared_testing_core2.yaml
@@ -1,4 +1,5 @@
 name: shared_testing_core1
+type: compute
 
 memories:
   sram_64KB:

--- a/stream/inputs/testing/hardware/cores/simd.yaml
+++ b/stream/inputs/testing/hardware/cores/simd.yaml
@@ -1,4 +1,5 @@
 name: pooling
+type: compute
 
 memories:
   sram_128KB_2rw:

--- a/stream/inputs/testing/hardware/cores/testing_core1.yaml
+++ b/stream/inputs/testing/hardware/cores/testing_core1.yaml
@@ -1,4 +1,5 @@
 name: testing_core1
+type: compute
 
 memories:
   rf_1B_I:

--- a/stream/inputs/testing/hardware/cores/testing_core2.yaml
+++ b/stream/inputs/testing/hardware/cores/testing_core2.yaml
@@ -1,4 +1,5 @@
 name: testing_core2
+type: compute
 
 memories:
   rf_1B_I:

--- a/stream/inputs/testing/hardware/cores/tpu_like.yaml
+++ b/stream/inputs/testing/hardware/cores/tpu_like.yaml
@@ -1,4 +1,5 @@
 name: tpu_like
+type: compute
 
 memories:
   rf_128B:

--- a/stream/inputs/testing/hardware/dual_testing_core_offchip.yaml
+++ b/stream/inputs/testing/hardware/dual_testing_core_offchip.yaml
@@ -1,15 +1,22 @@
+# Two heterogeneous compute cores with an explicit off-chip DRAM controller
 name: testing-2-core-with-offchip
+
+# Core catalogue (id ➜ YAML description)
 cores:
-  # index corresponds to core ID
-  - stream/inputs/testing/hardware/cores/testing_core1.yaml
-  - stream/inputs/testing/hardware/cores/testing_core2.yaml
-  - offchip.yaml
+  0: stream/inputs/testing/hardware/cores/testing_core1.yaml   # compute core A
+  1: stream/inputs/testing/hardware/cores/testing_core2.yaml   # compute core B
+  2: offchip.yaml                                             # DRAM controller
 
-graph:
-  type: 2d_mesh
-  nb_rows: 1
-  nb_cols: 2
-  bandwidth: 64
-  unit_energy_cost: 0
-  offchip_core_id: 2
+offchip_core_id: 2      # which core fronts external memory
+unit_energy_cost: 0     # default energy per transferred word
 
+core_connectivity:
+  # Direct link between the two compute cores
+  - type: link
+    cores: [0, 1]
+    bandwidth: 64
+
+  # Shared bus to off-chip memory (all on-chip cores + controller)
+  - type: bus
+    cores: [0, 1, 2]
+    bandwidth: 128

--- a/stream/inputs/testing/hardware/quad_testing_core_offchip.yaml
+++ b/stream/inputs/testing/hardware/quad_testing_core_offchip.yaml
@@ -1,19 +1,32 @@
+# 2 × 2 compute mesh with a shared off-chip DRAM controller
 name: testing-4-core-with-offchip
+
 cores:
-  # index corresponds to core ID
-  - testing_core1.yaml
-  - testing_core1.yaml
-  - testing_core1.yaml
-  - testing_core1.yaml
-  - offchip.yaml
+  0: testing_core1.yaml   # compute
+  1: testing_core1.yaml   # compute
+  2: testing_core1.yaml   # compute
+  3: testing_core1.yaml   # compute
+  4: offchip.yaml         # DRAM controller
 
-graph:
-  type: 2d_mesh
-  nb_rows: 2
-  nb_cols: 2
-  bandwidth: 64
-  unit_energy_cost: 0
-  offchip_core_id: 4
+offchip_core_id: 4        # core that fronts external memory
+unit_energy_cost: 0       # default energy per transferred word
 
+core_connectivity:
+  # ───── 2-D mesh links between compute cores ─────
+  - type: link             # 0 ↔ 1 (top row, horizontal)
+    cores: [0, 1]
+    bandwidth: 64
+  - type: link             # 0 ↔ 2 (left column, vertical)
+    cores: [0, 2]
+    bandwidth: 64
+  - type: link             # 1 ↔ 3 (right column, vertical)
+    cores: [1, 3]
+    bandwidth: 64
+  - type: link             # 2 ↔ 3 (bottom row, horizontal)
+    cores: [2, 3]
+    bandwidth: 64
 
-
+  # ───── Shared bus to off-chip memory ─────
+  - type: bus
+    cores: [0, 1, 2, 3, 4] # all cores share one medium
+    bandwidth: 128         # wider than on-chip links

--- a/stream/inputs/testing/hardware/simple_example_hw.yaml
+++ b/stream/inputs/testing/hardware/simple_example_hw.yaml
@@ -1,19 +1,41 @@
+# Two meta-prototype compute cores plus pooling, SIMD and an off-chip DRAM controller
 name: meta-proto-2-core-with-pooling-and-offchip-cores
+
+# Core catalogue (id ➜ YAML description)
 cores:
-  # index corresponds to core ID
-  - meta_prototype.yaml
-  - meta_prototype.yaml
-  - pooling.yaml
-  - simd.yaml
-  - offchip.yaml
+  0: meta_prototype.yaml   # compute-core A
+  1: meta_prototype.yaml   # compute-core B
+  2: pooling.yaml          # dedicated pooling engine
+  3: simd.yaml             # general SIMD unit
+  4: offchip.yaml          # DRAM controller
 
-graph:
-  type: 2d_mesh
-  nb_rows: 1
-  nb_cols: 2
-  bandwidth: 64
-  unit_energy_cost: 0
-  pooling_core_id: 2
-  simd_core_id: 3
-  offchip_core_id: 4
+offchip_core_id: 4         # which core provides external memory
+unit_energy_cost: 0        # default energy per word
 
+# Explicit on-chip topology
+core_connectivity:
+  # ───── 2-D mesh link between the two compute cores ─────
+  - type: link
+    cores: [0, 1]
+    bandwidth: 64
+
+  # ───── Pooling core connected to each compute core ────
+  - type: link
+    cores: [0, 2]
+    bandwidth: 64
+  - type: link
+    cores: [1, 2]
+    bandwidth: 64
+
+  # ───── SIMD core connected to each compute core ───────
+  - type: link
+    cores: [0, 3]
+    bandwidth: 64
+  - type: link
+    cores: [1, 3]
+    bandwidth: 64
+
+  # ───── Shared off-chip bus (all cores ↔ DRAM) ─────────
+  - type: bus
+    cores: [0, 1, 2, 3, 4]   # includes the DRAM controller itself
+    bandwidth: 128           # fatter than on-chip links

--- a/stream/inputs/testing/hardware/single_testing_core_offchip.yaml
+++ b/stream/inputs/testing/hardware/single_testing_core_offchip.yaml
@@ -1,16 +1,19 @@
+# Minimal single-core accelerator with an explicit off-chip memory controller
 name: testing-1-core-with-offchip
+
+# Mapping from core-ID → YAML description file
 cores:
-  # index corresponds to core ID
-  - testing_core1.yaml
-  - offchip.yaml
+  0: testing_core1.yaml        # compute core
+  1: offchip.yaml              # DRAM controller
 
-graph:
-  type: 2d_mesh
-  nb_rows: 1
-  nb_cols: 1
-  bandwidth: 64
-  unit_energy_cost: 0
-  offchip_core_id: 1
+# ID of the core that provides the external memory interface
+offchip_core_id: 1
 
+# Default energy cost per word (overridable per connection)
+unit_energy_cost: 0
 
-
+# Explicit connectivity list
+core_connectivity:
+  - type: link                 # point-to-point connection
+    cores: [0, 1]              # compute ↔ off-chip
+    bandwidth: 64              # GB/s (or your chosen units)

--- a/stream/inputs/testing/hardware/tpu_like_quad_core.yaml
+++ b/stream/inputs/testing/hardware/tpu_like_quad_core.yaml
@@ -7,24 +7,67 @@ cores:
   3: tpu_like.yaml
   4: pooling.yaml
   5: simd.yaml
-offchip_core: offchip.yaml
+  6: offchip.yaml
+
+offchip_core_id: 6
 
 core_connectivity:
-  # 2D mesh
-  - 0, 1
-  - 1, 2
-  - 2, 3
-  - 3, 0
-  # Connect pooling core to all
-  - 0, 4
-  - 1, 4
-  - 2, 4
-  - 3, 4
-  # Connect SIMD to all
-  - 0, 5
-  - 1, 5
-  - 2, 5
-  - 3, 5
+  # -------- 2-D mesh among compute cores (point-to-point links) ------------- #
+  - type: link
+    cores: [0, 1]
+    bandwidth: 128
+    unit_energy_cost: 0
+  - type: link
+    cores: [1, 2]
+    bandwidth: 128
+    unit_energy_cost: 0
+  - type: link
+    cores: [2, 3]
+    bandwidth: 128
+    unit_energy_cost: 0
+  - type: link
+    cores: [3, 0]
+    bandwidth: 128
+    unit_energy_cost: 0
 
-bandwidth: 128
-unit_energy_cost: 0
+  # -------------- Pooling core (id 4) linked to each compute core ----------- #
+  - type: link
+    cores: [0, 4]
+    bandwidth: 128
+    unit_energy_cost: 0
+  - type: link
+    cores: [1, 4]
+    bandwidth: 128
+    unit_energy_cost: 0
+  - type: link
+    cores: [2, 4]
+    bandwidth: 128
+    unit_energy_cost: 0
+  - type: link
+    cores: [3, 4]
+    bandwidth: 128
+    unit_energy_cost: 0
+
+  # -------------- SIMD core (id 5) linked to each compute core -------------- #
+  - type: link
+    cores: [0, 5]
+    bandwidth: 128
+    unit_energy_cost: 0
+  - type: link
+    cores: [1, 5]
+    bandwidth: 128
+    unit_energy_cost: 0
+  - type: link
+    cores: [2, 5]
+    bandwidth: 128
+    unit_energy_cost: 0
+  - type: link
+    cores: [3, 5]
+    bandwidth: 128
+    unit_energy_cost: 0
+
+  # -------- Shared off-chip memory bus: all cores share one medium ---------- #
+  - type: bus
+    cores: [0, 1, 2, 3, 4, 5, 6]  # includes the DRAM controller itself
+    bandwidth: 512               # fatter than on-chip links
+    unit_energy_cost: 0

--- a/stream/parser/accelerator_factory.py
+++ b/stream/parser/accelerator_factory.py
@@ -1,8 +1,6 @@
 from typing import Any
 
-from zigzag.datatypes import Constants
 from zigzag.hardware.architecture.memory_level import MemoryLevel
-from zigzag.hardware.architecture.memory_port import MemoryPortType
 from zigzag.parser.accelerator_factory import AcceleratorFactory as ZigZagCoreFactory
 
 from stream.hardware.architecture.accelerator import Accelerator, CoreGraph
@@ -36,15 +34,10 @@ class AcceleratorFactory:
                 "both yaml files, including the memory instance name."
             )
 
-        # Create offchip core
-        if "offchip_core" not in self.data:
-            offchip_core_id = None
-            offchip_core = None
-        else:
-            offchip_core_id = max(self.data["cores"]) + 1
-            offchip_core = self.create_core(self.data["offchip_core"], offchip_core_id)
+        # Save offchip core id if it exists
+        offchip_core_id = self.data.get("offchip_core_id", None)
 
-        cores_graph = self.create_core_graph(cores, offchip_core)
+        cores_graph = self.create_core_graph(cores)
         nb_shared_mem_groups = len(unique_shared_mem_group_ids)
 
         # Take next available core id
@@ -106,82 +99,51 @@ class AcceleratorFactory:
                 return True
         return False
 
-    def create_core_graph(self, cores: list[Core], offchip_core: Core | None):
+    def create_core_graph(self, cores: list[Core]):
         assert all(core.id == i for i, core in enumerate(cores))
-        bandwidth = self.data["bandwidth"]
-        unit_energy_cost = self.data["unit_energy_cost"]
-        connections: list[tuple[int, ...]] = self.data["core_connectivity"]
         edges: list[tuple[Core, Core, dict[str, CommunicationLink]]] = []
         current_bus_id = 0
+        core_connectivity: list[dict[str, Any]] = self.data["core_connectivity"]
+        default_unit_energy_cost = self.data.get("unit_energy_cost", 0)
 
         # All links between cores
-        for connection in connections:
-            connected_cores = [cores[core_id] for core_id in connection]
+        for connection in core_connectivity:
+            connection_type = connection.get("type", "link")
+            bw = connection["bandwidth"]
+            uec = connection.get("unit_energy_cost", default_unit_energy_cost)
+            core_objs = [cores[cid] for cid in connection["cores"]]
             CONNECTION_LENGTH_FOR_ONE_TO_ONE = 2
-            if len(connection) == CONNECTION_LENGTH_FOR_ONE_TO_ONE:
-                core_a, core_b = connected_cores
+            if connection_type == "link":
+                if len(core_objs) != CONNECTION_LENGTH_FOR_ONE_TO_ONE:
+                    raise ValueError(
+                        f"Invalid connection type '{connection_type}' for connection {core_objs}. "
+                        f"Expected exactly {CONNECTION_LENGTH_FOR_ONE_TO_ONE} cores for a link."
+                    )
+                core_a, core_b = core_objs
                 edges += get_bidirectional_edges(
                     core_a,
                     core_b,
-                    bandwidth=bandwidth,
-                    unit_energy_cost=unit_energy_cost,
-                    link_type="link",
+                    bandwidth=bw,
+                    unit_energy_cost=uec,
+                    link_type=connection_type,
                 )
-            else:
+            elif connection_type == "bus":
                 # Connect cores to bus, edge by edge
                 # Make sure all links refer to the same `CommunicationLink` instance
-                bus_instance = CommunicationLink("Any", "Any", bandwidth, unit_energy_cost, bus_id=current_bus_id)
+                bus_instance = CommunicationLink("Any", "Any", bw, uec, bus_id=current_bus_id)
                 current_bus_id += 1
-                pairs_this_connection = [
-                    (a, b) for idx, a in enumerate(connected_cores) for b in connected_cores[idx + 1 :]
-                ]
+                pairs_this_connection = [(a, b) for idx, a in enumerate(core_objs) for b in core_objs[idx + 1 :]]
                 for core_a, core_b in pairs_this_connection:
                     edges += get_bidirectional_edges(
                         core_a,
                         core_b,
-                        bandwidth=bandwidth,
-                        unit_energy_cost=unit_energy_cost,
+                        bandwidth=bw,
+                        unit_energy_cost=uec,
                         link_type="bus",
                         bus_instance=bus_instance,
                     )
-
-        # All links between cores and offchip core
-        if offchip_core is not None:
-            edges += self.get_edges_to_offchip_core(cores, offchip_core)
+            else:
+                raise ValueError(
+                    f"Invalid connection type '{connection_type}' for connection {core_objs}. Expected 'link' or 'bus'."
+                )
         return CoreGraph(edges)
-
-    def get_edges_to_offchip_core(self, cores: list[Core], offchip_core: Core):
-        edges: list[tuple[Core, Core, dict[str, CommunicationLink]]] = []
-
-        unit_energy_cost = self.data["unit_energy_cost"]
-
-        # Get the first read port of the offchip core's top memory
-        offchip_ports = offchip_core.get_top_memory_instance(Constants.OUTPUT_MEM_OP).ports
-        port = next(port for port in offchip_ports if port.type in (MemoryPortType.READ, MemoryPortType.READ_WRITE))
-        offchip_read_bandwidth = port.bw_max
-        # Get the first write port of the offchip core's top memory
-        port = next(port for port in offchip_ports if port.type in (MemoryPortType.WRITE, MemoryPortType.READ_WRITE))
-        offchip_write_bandwidth = port.bw_max
-
-        # if the offchip core has only one port
-        if len(offchip_ports) == 1:
-            to_offchip_link = CommunicationLink(
-                offchip_core,
-                "Any",
-                offchip_write_bandwidth,
-                unit_energy_cost,
-                bidirectional=True,
-            )
-            from_offchip_link = to_offchip_link
-
-        # if the offchip core has more than one port
-        else:
-            to_offchip_link = CommunicationLink("Any", offchip_core, offchip_write_bandwidth, unit_energy_cost)
-            from_offchip_link = CommunicationLink(offchip_core, "Any", offchip_read_bandwidth, unit_energy_cost)
-
-        # Create edge for each core
-        for core in cores:
-            edges.append((core, offchip_core, {"cl": to_offchip_link}))
-            edges.append((offchip_core, core, {"cl": from_offchip_link}))
-
-        return edges

--- a/stream/parser/accelerator_factory.py
+++ b/stream/parser/accelerator_factory.py
@@ -60,6 +60,7 @@ class AcceleratorFactory:
         core = core_factory.create(core_id, shared_mem_group_id=shared_mem_group_id)
         # Typecast
         core = Core.from_zigzag_core(core)
+        core.type = core_data.get("type", "compute")  # Default type is 'compute'
         return core
 
     def get_shared_mem_group_id(self, core_id: int):

--- a/stream/parser/accelerator_validator.py
+++ b/stream/parser/accelerator_validator.py
@@ -14,21 +14,65 @@ logger = logging.getLogger(__name__)
 
 class AcceleratorValidator:
     INPUT_DIR_LOCATION = "stream/inputs/"
-    GRAPH_TYPES = ["2d_mesh", "bus"]
     FILENAME_REGEX = r"^(?:[a-zA-Z0-9_\-]+|[a-zA-Z0-9_\-\///]+(\.yaml|\.yml))$"
-    CORE_IDS_REGEX = r"^(\d+\s*,\s*)+\d+$"
+    CORE_IDS_REGEX = r"^\d+(?:\s*,\s*\d+){1,}$"
 
     SCHEMA: dict[str, Any] = {
+        # ------------------------------------------------------------------ #
+        # Basic identification                                               #
+        # ------------------------------------------------------------------ #
         "name": {"type": "string", "required": True},
+        # ------------------------------------------------------------------ #
+        # Core catalogue (file names relative to the inputs folder)          #
+        # ------------------------------------------------------------------ #
         "cores": {
             "type": "dict",
             "required": True,
             "valuesrules": {"type": "string", "regex": FILENAME_REGEX},
         },
-        "offchip_core": {"type": "string", "regex": FILENAME_REGEX, "required": False},
-        "unit_energy_cost": {"type": "float", "default": 0},
-        "bandwidth": {"type": "float", "required": True},
-        "core_connectivity": {"type": "list", "required": True, "schema": {"type": "string", "regex": CORE_IDS_REGEX}},
+        # Id of the core that acts as the off-chip memory controller
+        "offchip_core_id": {"type": "integer", "min": 0, "required": True},
+        # ------------------------------------------------------------------ #
+        # Optional unit_energy_cost that is used for all connections         #
+        # that don't specify their own unit_energy_cost                      #
+        # ------------------------------------------------------------------ #
+        "unit_energy_cost": {
+            "type": "float",
+            "min": 0,
+            "required": False,
+            "default": 0,
+        },
+        # ------------------------------------------------------------------ #
+        # Topology description                                               #
+        # ------------------------------------------------------------------ #
+        "core_connectivity": {
+            "type": "list",
+            "required": True,
+            "schema": {
+                "type": "dict",
+                "schema": {
+                    # "link" = point-to-point, "bus" = shared medium
+                    "type": {
+                        "type": "string",
+                        "allowed": ["link", "bus"],
+                        "default": "link",
+                    },
+                    # List of core ids that participate in this connection
+                    "cores": {
+                        "type": "list",
+                        "minlength": 2,
+                        "schema": {"type": "integer", "min": 0},
+                    },
+                    # Peak bandwidth for the link / bus (GB/s or chosen units)
+                    "bandwidth": {"type": "float", "min": 0, "required": True},
+                    # Optional override of the global unit energy cost
+                    "unit_energy_cost": {"type": "float", "min": 0, "required": False},
+                },
+            },
+        },
+        # ------------------------------------------------------------------ #
+        # Optional memory-sharing groups                                     #
+        # ------------------------------------------------------------------ #
         "core_memory_sharing": {
             "type": "list",
             "default": [],
@@ -73,6 +117,8 @@ class AcceleratorValidator:
             self.invalidate("Invalid core id in `cores`: id is not a positive integer.")
         if len(core_ids) != max(core_ids) + 1:
             self.invalidate("Invalid core id in `cores`: not all core ids in range are in use.")
+        if self.data["offchip_core_id"] not in core_ids:
+            self.invalidate("offchip_core_id does not correspond to any entry in `cores`.")
 
     def validate_all_cores(self) -> None:
         """For all given core file paths:
@@ -87,14 +133,6 @@ class AcceleratorValidator:
             if not normalized_core_data:
                 return
             self.data["cores"][core_id] = normalized_core_data
-
-        # Offchip core (not part of cores list)
-        if "offchip_core" in self.data:
-            offchip_core_file_name = self.data["offchip_core"]
-            normalized_core_data = self.validate_single_core(offchip_core_file_name)
-            if not normalized_core_data:
-                return
-            self.data["offchip_core"] = normalized_core_data
 
     def validate_single_core(self, core_file_name: str) -> None | dict[str, Any]:
         core_data = self.open_core(core_file_name)
@@ -139,26 +177,28 @@ class AcceleratorValidator:
         return None
 
     def validate_core_connectivity(self):
-        connectivity_data = self.data["core_connectivity"]
+        connections = self.data["core_connectivity"]
+        if connections == []:
+            return  # empty graph is allowed
 
-        # Empty data is okay
-        if connectivity_data == []:
-            return
+        core_ids = set(self.data["cores"].keys())
+        for idx, conn in enumerate(connections):
+            cores = conn["cores"]
+            bw = conn["bandwidth"]
+            ue = conn.get("unit_energy_cost", self.data.get("unit_energy_cost", 0))
 
-        # Replace string of core ids with tuple of ints
-        connectivity_groups = [tuple(int(i) for i in group.replace(" ", "").split(",")) for group in connectivity_data]
-        self.data["core_connectivity"] = connectivity_groups
+            # basic semantic checks (most syntactic ones are done by Cerberus)
+            if not all(cid in core_ids for cid in cores):
+                self.invalidate(f"`core_connectivity[{idx}].cores` contains unknown core id.")
+            if bw <= 0:
+                self.invalidate(f"`core_connectivity[{idx}].bandwidth` must be > 0.")
+            if ue < 0:
+                self.invalidate(f"`core_connectivity[{idx}].unit_energy_cost` must be ≥ 0.")
 
-        all_connected_core_ids = reduce(lambda x, y: x + y, connectivity_groups)
-        core_ids = list(self.data["cores"].keys())
-
-        # Connection length >= 2
-        if not all(len(group) > 1 for group in connectivity_groups):
-            self.invalidate("Core connection should contain at least 2 core ids.")
-
-        # No unknown core ids
-        if not all(connected_id in core_ids for connected_id in all_connected_core_ids):
-            self.invalidate("`core_connectivity` contains unknown core id.")
+            # normalise: store cores as an immutable tuple & fill in defaults
+            conn["cores"] = tuple(cores)
+            conn.setdefault("type", "link")
+            conn.setdefault("unit_energy_cost", self.data.get("unit_energy_cost", 0))
 
     def validate_core_mem_sharing(self):
         # Replace string of core ids with tuple of ints
@@ -180,14 +220,11 @@ class AcceleratorValidator:
             self.invalidate("`core_memory_sharing` contains unknown core id.")
 
         # Cores that share memory should not have an explicit connection
-        connectivity_groups = self.data["core_connectivity"]
+        connectivity_groups = [set(conn["cores"]) for conn in self.data["core_connectivity"]]
         for mem_sharing_group in mem_sharing_groups:
             # Check each link within the mem_sharing_group
             for id_a, id_b in combinations(mem_sharing_group, 2):
-                if any(
-                    id_a in connectivity_group and id_b in connectivity_group
-                    for connectivity_group in connectivity_groups
-                ):
+                if any({id_a, id_b}.issubset(group) for group in connectivity_groups):
                     self.invalidate(
                         "Cores that share memory should must not be explicitly connected in `core_connectivity`"
                     )

--- a/stream/parser/core_validator.py
+++ b/stream/parser/core_validator.py
@@ -9,7 +9,9 @@ class CoreValidator(ZigZagAcceleratorValidator):
     SCHEMA = ZigZagAcceleratorValidator.SCHEMA.copy()
 
     # Add custom schema rules for Stream accelerator cores here
+    SCHEMA.update({"type": {"type": "string", "required": True, "allowed": ["memory", "compute"]}})
 
     def __init__(self, data: Any):
         """Initialize Validator object, assign schema and store normalize user-given data"""
         super().__init__(data)
+        self.validator.schema = self.SCHEMA  # type: ignore

--- a/stream/stages/generation/tiled_workload_generation.py
+++ b/stream/stages/generation/tiled_workload_generation.py
@@ -157,6 +157,7 @@ class TiledWorkloadGenerationStage(Stage):
 
             # The graph construction needs to happen after the base priority and nb_real_predecessors are set
             tiled_workload = ComputationNodeWorkload()
+            tiled_workload.add_nodes_from(all_tiles)
             tiled_workload.add_edges_from(all_edges)
 
             # Set the base_priority and number of real predecessors of all nodes


### PR DESCRIPTION
This PR updates the accelerator hardware input definition to be more flexible in terms of core_connectivity. The `offchip_core` is now defined as another core and the `offchip_core_id` should be specified to denote the core number of this `offchip_core`.

All relevant input hardware definitions have been updated to this new format.

It also adds a required `type` field for all cores of the accelerator, which can be set to `"compute"` or `"memory"`. Currently, these fields are not used.